### PR TITLE
Fix Vercel NOT_FOUND (SPA rewrite) + deterministic typecheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,22 @@ HOTMESS is more than just a social network—it's a vibrant community hub that c
 - `npm run preview` - Preview production build locally
 - `npm run lint` - Run ESLint code quality checks
 - `npm run lint:fix` - Automatically fix ESLint issues
-- `npm run typecheck` - Run TypeScript type checking
+- `npm run typecheck` - Run TypeScript type checking (`tsc --noEmit`)
+
+## ▲ Deploying to Vercel
+
+This app is a Vite SPA using React Router. Deep links like `/${PageKey}` require an SPA rewrite.
+
+- Vercel settings:
+   - Framework Preset: Vite
+   - Build Command: `npm run build`
+   - Output Directory: `dist`
+- Environment Variables (Vercel Project → Settings → Environment Variables):
+   - Required: `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`
+   - Optional: `VITE_SUPABASE_STORAGE_BUCKET`
+   - Optional: `VITE_BASE44_APP_BASE_URL` (set to your production URL)
+- Routing:
+   - `vercel.json` includes an SPA rewrite to `index.html` for all routes.
 
 ## 🏗️ Technology Stack
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint . --quiet",
     "lint:fix": "eslint . --fix",
-    "typecheck": "tsc -p ./jsconfig.json",
+    "typecheck": "node ./node_modules/typescript/bin/tsc -p ./jsconfig.json --noEmit",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
This PR fixes Vercel platform 404/NOT_FOUND on deep links (React Router PageKey routes) by adding an SPA rewrite.

Changes:
- Add `vercel.json` rewrite to route all paths to `/index.html`
- Make `npm run typecheck` deterministic (`tsc --noEmit`)
- README: add minimal Vercel deployment notes and clarify typecheck

How to test:
- Deploy this branch on Vercel
- Visit `/Globe` or `/Events` directly and refresh (should render app, not Vercel NOT_FOUND)
