### PR TITLE
feat(v6-01): Runtime Isolation — FIELD_MANIFEST + sanitiseForAI + 9 tests + isolation_audit_log

### DIFF
--- a/src/lib/v6/fieldManifest.js
+++ b/src/lib/v6/fieldManifest.js
@@ -1,0 +1,150 @@
+/**
+ * HOTMESS v6 — Runtime Isolation: Field Manifest
+ * Source of truth for per-service access control.
+ * Every service that queries the DB or calls another service
+ * must be listed here. Enforcement is at runtime via
+ * enforceFieldAccess() in isolationEnforcement.js.
+ *
+ * Spec: HOTMESS-RuntimeEnforcement.docx §2
+ *       HOTMESS-SystemIsolationMap.docx §3
+ */
+
+/** Fields no service may pass to an AI context. Ever. */
+export const AI_BLOCKED_FIELDS = [
+  'support_preferences',
+  'lifestyle_preferences',
+  'support_notifications_enabled',
+  'support_detail_level',
+  'backup_contacts',
+  'care_settings',
+  'safety_alerts',
+  'get_out_enabled',
+  'land_time',
+  'moderation_history',
+  'risk_flags',
+  'report_history',
+];
+
+/** Supabase Realtime channels permitted to broadcast. */
+export const ALLOWED_REALTIME_CHANNELS = [
+  'public_movement_presence',
+  'meet_sessions',
+  'beacon_state',
+  'notifications',
+];
+
+/** Tables that must never appear in any Realtime broadcast. */
+export const REALTIME_BLOCKED_TABLES = [
+  'support_preferences',
+  'lifestyle_preferences',
+  'backup_contacts',
+  'safety_alerts',
+  'care_settings',
+  'moderation_reports',
+  'age_verification_log',
+];
+
+/**
+ * Per-service field declarations.
+ * `allowed` — fields this service may read.
+ * `blocked` — fields that throw immediately if requested.
+ *
+ * A field not listed in either array is treated as blocked
+ * (fail-closed).
+ */
+export const FIELD_MANIFEST = {
+  AI_LAYER: {
+    allowed: [
+      'chat_text',
+      'movement_state',
+      'right_now_status',
+      'venue_context',
+      'event_data',
+      'meet_stage',
+    ],
+    blocked: [
+      'support_preferences',
+      'lifestyle_preferences',
+      'backup_contacts',
+      'care_settings',
+      'safety_alerts',
+      'historical_sessions',
+      'moderation_history',
+    ],
+  },
+
+  OPERATOR_PANEL: {
+    allowed: [
+      'beacon_state',
+      'event_rsvp_count',
+      'checkin_rate',
+      'peak_time_aggregate',
+      'aa_state_readonly',
+    ],
+    blocked: [
+      'user_location',
+      'movement_state',
+      'chat_content',
+      'support_preferences',
+      'lifestyle_preferences',
+      'care_settings',
+      'backup_contacts',
+      'meet_sessions',
+    ],
+  },
+
+  MEET_SYSTEM: {
+    allowed: [
+      'location_session',
+      'movement_state',
+      'meet_sessions',
+      'right_now_status',
+      'chat_thread_meet',
+    ],
+    blocked: [
+      'support_preferences',
+      'lifestyle_preferences',
+      'backup_contacts',
+      'care_settings',
+      'operator_data',
+      'globe_aggregate',
+      'ai_outputs',
+    ],
+  },
+
+  NOTIFICATIONS: {
+    allowed: [
+      'notification_prefs',
+      'support_notifications_enabled',
+      'movement_state',
+      'meet_stage',
+    ],
+    blocked: [
+      'support_detail_level_external',
+      'lifestyle_preferences',
+      'care_alert_content',
+      'other_user_notif_state',
+    ],
+  },
+
+  GLOBE_SYSTEM: {
+    allowed: [
+      'globe_signals',
+      'crowd_density',
+      'beacon_intensity',
+      'aa_state',
+      'event_state',
+      'movement_session_count',
+    ],
+    blocked: [
+      'user_location',
+      'chat_content',
+      'meet_sessions',
+      'support_preferences',
+      'lifestyle_preferences',
+      'care_settings',
+      'backup_contacts',
+      'ai_outputs',
+    ],
+  },
+};

--- a/src/lib/v6/isolationEnforcement.js
+++ b/src/lib/v6/isolationEnforcement.js
@@ -1,0 +1,188 @@
+/**
+ * HOTMESS v6 — Runtime Isolation: Enforcement Helpers
+ *
+ * enforceFieldAccess(service, fields)
+ *   — throws ForbiddenError if any field violates the FIELD_MANIFEST.
+ *   — call before every DB query or service-to-service call.
+ *
+ * sanitiseForAI(context)
+ *   — throws IsolationViolationError if any AI_BLOCKED_FIELD is present.
+ *   — call BEFORE assembling AI context, not after.
+ *   — throws, never strips (hiding violations is not acceptable).
+ *
+ * logIsolationViolation(payload)
+ *   — writes an append-only row to isolation_audit_log in Supabase.
+ *   — called automatically by enforceFieldAccess and sanitiseForAI.
+ *
+ * Spec: HOTMESS-RuntimeEnforcement.docx §2, §5, §8
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { FIELD_MANIFEST, AI_BLOCKED_FIELDS, ALLOWED_REALTIME_CHANNELS } from './fieldManifest.js';
+
+// ---------------------------------------------------------------------------
+// Custom error classes
+// ---------------------------------------------------------------------------
+
+export class IsolationViolationError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = 'IsolationViolationError';
+    this.details = details;
+  }
+}
+
+export class ForbiddenError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = 'ForbiddenError';
+    this.details = details;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Supabase client (service-role for audit writes — no RLS bypass elsewhere)
+// ---------------------------------------------------------------------------
+
+function _getAuditClient() {
+  const url  = import.meta?.env?.VITE_SUPABASE_URL  ?? process.env.VITE_SUPABASE_URL;
+  const key  = import.meta?.env?.VITE_SUPABASE_SERVICE_KEY ?? process.env.VITE_SUPABASE_SERVICE_KEY
+             ?? import.meta?.env?.VITE_SUPABASE_ANON_KEY   ?? process.env.VITE_SUPABASE_ANON_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key);
+}
+
+// ---------------------------------------------------------------------------
+// Audit logger — append-only, never throws (best-effort)
+// ---------------------------------------------------------------------------
+
+export async function logIsolationViolation({
+  event_type,
+  service,
+  field,
+  user_id   = null,
+  request_id = null,
+  stack_trace = null,
+}) {
+  try {
+    const client = _getAuditClient();
+    if (!client) return; // no-op in unit-test environments without env vars
+    await client.from('isolation_audit_log').insert({
+      event_type,
+      service,
+      field,
+      user_id,
+      request_id,
+      stack_trace,
+    });
+  } catch {
+    // Audit logging must never crash the calling code.
+    // Violations are surfaced via the thrown error, not the log.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// enforceFieldAccess — service field manifest check
+// ---------------------------------------------------------------------------
+
+/**
+ * Enforce that `service` is permitted to access every field in `fields`.
+ *
+ * @param {string}   service  — key in FIELD_MANIFEST (e.g. "AI_LAYER")
+ * @param {string[]} fields   — field names being requested
+ * @param {object}   [opts]   — { userId, requestId } for audit context
+ * @throws {ForbiddenError}   on first blocked field found
+ */
+export async function enforceFieldAccess(service, fields, opts = {}) {
+  const manifest = FIELD_MANIFEST[service];
+  if (!manifest) {
+    throw new ForbiddenError(
+      `Unknown service "${service}". Every service must be declared in FIELD_MANIFEST.`,
+      { service }
+    );
+  }
+
+  for (const field of fields) {
+    if (manifest.blocked.includes(field)) {
+      await logIsolationViolation({
+        event_type:  'BLOCKED_FIELD_ACCESS',
+        service,
+        field,
+        user_id:     opts.userId    ?? null,
+        request_id:  opts.requestId ?? null,
+        stack_trace: new Error().stack,
+      });
+
+      throw new ForbiddenError(
+        `${service} cannot access field "${field}". Isolation violation.`,
+        { service, field }
+      );
+    }
+
+    // Fail-closed: field not in allowed OR blocked is also rejected.
+    if (!manifest.allowed.includes(field) && !manifest.blocked.includes(field)) {
+      await logIsolationViolation({
+        event_type:  'BLOCKED_FIELD_ACCESS',
+        service,
+        field,
+        user_id:     opts.userId    ?? null,
+        request_id:  opts.requestId ?? null,
+        stack_trace: new Error().stack,
+      });
+
+      throw new ForbiddenError(
+        `${service} has no declared access to field "${field}". Fail-closed.`,
+        { service, field }
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// sanitiseForAI — pre-call AI context guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify that `context` contains no AI-blocked fields.
+ * Throws before the AI call is made — never strips and continues.
+ *
+ * @param {object} context    — the assembled AI context object
+ * @param {object} [opts]     — { userId, requestId } for audit context
+ * @returns {object}          — the original context (unmodified) if clean
+ * @throws {IsolationViolationError} on first blocked field found
+ */
+export async function sanitiseForAI(context, opts = {}) {
+  for (const field of AI_BLOCKED_FIELDS) {
+    if (field in context) {
+      await logIsolationViolation({
+        event_type:  'AI_BLOCKED_FIELD_DETECTED',
+        service:     'AI_LAYER',
+        field,
+        user_id:     opts.userId    ?? null,
+        request_id:  opts.requestId ?? null,
+        stack_trace: new Error().stack,
+      });
+
+      throw new IsolationViolationError(
+        `Blocked field "${field}" detected in AI context. Call aborted.`,
+        { field }
+      );
+    }
+  }
+  return context;
+}
+
+// ---------------------------------------------------------------------------
+// realtimeChannelAllowed — guard for Supabase Realtime subscriptions
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true only if the channel is in the permitted broadcast list.
+ * Use at subscription setup — reject anything not on the allowlist.
+ *
+ * @param {string} channelName
+ * @returns {boolean}
+ */
+export function realtimeChannelAllowed(channelName) {
+  return ALLOWED_REALTIME_CHANNELS.includes(channelName);
+}

--- a/src/test/isolationEnforcement.test.js
+++ b/src/test/isolationEnforcement.test.js
@@ -1,0 +1,226 @@
+/**
+ * HOTMESS v6 — Runtime Isolation: Enforcement Tests
+ *
+ * All 9 isolation tests from HOTMESS-RuntimeEnforcement.docx §7.
+ * Every test must pass on every deploy. Any failure blocks the pipeline.
+ *
+ * These tests are pure unit tests — no DB, no network.
+ * The logIsolationViolation() call inside enforceFieldAccess / sanitiseForAI
+ * is a best-effort fire-and-forget; its failure never masks the thrown error
+ * we're testing for.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── mock Supabase so tests never hit the network ──────────────────────────
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({ insert: vi.fn().mockResolvedValue({ error: null }) }),
+  }),
+}));
+
+import {
+  enforceFieldAccess,
+  sanitiseForAI,
+  IsolationViolationError,
+  ForbiddenError,
+} from '@/lib/v6/isolationEnforcement';
+
+import {
+  REALTIME_BLOCKED_TABLES,
+  ALLOWED_REALTIME_CHANNELS,
+  AI_BLOCKED_FIELDS,
+} from '@/lib/v6/fieldManifest';
+
+// ---------------------------------------------------------------------------
+// Test 1 — AI cannot read support_preferences
+// ---------------------------------------------------------------------------
+describe('test_ai_cannot_read_support_prefs', () => {
+  it('throws IsolationViolationError when support_preferences is in AI context', async () => {
+    const context = {
+      chat_text: 'hello',
+      support_preferences: { sober: true },
+    };
+    await expect(sanitiseForAI(context)).rejects.toThrow(IsolationViolationError);
+    await expect(sanitiseForAI(context)).rejects.toThrow(
+      /Blocked field "support_preferences" detected in AI context/
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2 — AI cannot read lifestyle_preferences
+// ---------------------------------------------------------------------------
+describe('test_ai_cannot_read_lifestyle_flags', () => {
+  it('throws IsolationViolationError when lifestyle_preferences is in AI context', async () => {
+    const context = {
+      venue_context: 'Eagle Bar',
+      lifestyle_preferences: { role: 'top' },
+    };
+    await expect(sanitiseForAI(context)).rejects.toThrow(IsolationViolationError);
+    await expect(sanitiseForAI(context)).rejects.toThrow(
+      /Blocked field "lifestyle_preferences" detected in AI context/
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 3 — Operator panel cannot read individual user_location
+// ---------------------------------------------------------------------------
+describe('test_operator_cannot_read_user_location', () => {
+  it('throws ForbiddenError when OPERATOR_PANEL requests user_location', async () => {
+    await expect(
+      enforceFieldAccess('OPERATOR_PANEL', ['user_location'])
+    ).rejects.toThrow(ForbiddenError);
+    await expect(
+      enforceFieldAccess('OPERATOR_PANEL', ['user_location'])
+    ).rejects.toThrow(/OPERATOR_PANEL cannot access field "user_location"/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 4 — Operator panel cannot read care data (support_preferences)
+// ---------------------------------------------------------------------------
+describe('test_operator_cannot_read_care_data', () => {
+  it('throws ForbiddenError when OPERATOR_PANEL requests support_preferences', async () => {
+    await expect(
+      enforceFieldAccess('OPERATOR_PANEL', ['support_preferences'])
+    ).rejects.toThrow(ForbiddenError);
+  });
+
+  it('throws ForbiddenError when OPERATOR_PANEL requests care_settings', async () => {
+    await expect(
+      enforceFieldAccess('OPERATOR_PANEL', ['care_settings'])
+    ).rejects.toThrow(ForbiddenError);
+  });
+
+  it('throws ForbiddenError when OPERATOR_PANEL requests backup_contacts', async () => {
+    await expect(
+      enforceFieldAccess('OPERATOR_PANEL', ['backup_contacts'])
+    ).rejects.toThrow(ForbiddenError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 5 — Care events must not appear in Realtime broadcast channels
+// ---------------------------------------------------------------------------
+describe('test_care_event_not_in_realtime', () => {
+  it('care tables are all present in REALTIME_BLOCKED_TABLES', () => {
+    const careTables = [
+      'support_preferences',
+      'lifestyle_preferences',
+      'backup_contacts',
+      'safety_alerts',
+      'care_settings',
+    ];
+    for (const table of careTables) {
+      expect(REALTIME_BLOCKED_TABLES).toContain(table);
+    }
+  });
+
+  it('care tables are not listed in ALLOWED_REALTIME_CHANNELS', () => {
+    const careTables = [
+      'support_preferences',
+      'lifestyle_preferences',
+      'backup_contacts',
+      'safety_alerts',
+      'care_settings',
+    ];
+    for (const table of careTables) {
+      expect(ALLOWED_REALTIME_CHANNELS).not.toContain(table);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 6 — Notifications service cannot read lifestyle_preferences
+// ---------------------------------------------------------------------------
+describe('test_notifications_blocks_lifestyle', () => {
+  it('throws ForbiddenError when NOTIFICATIONS requests lifestyle_preferences', async () => {
+    await expect(
+      enforceFieldAccess('NOTIFICATIONS', ['lifestyle_preferences'])
+    ).rejects.toThrow(ForbiddenError);
+    await expect(
+      enforceFieldAccess('NOTIFICATIONS', ['lifestyle_preferences'])
+    ).rejects.toThrow(/NOTIFICATIONS cannot access field "lifestyle_preferences"/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 7 — Meet system cannot read backup_contacts (care field)
+// ---------------------------------------------------------------------------
+describe('test_meet_system_blocks_care_fields', () => {
+  it('throws ForbiddenError when MEET_SYSTEM requests backup_contacts', async () => {
+    await expect(
+      enforceFieldAccess('MEET_SYSTEM', ['backup_contacts'])
+    ).rejects.toThrow(ForbiddenError);
+  });
+
+  it('throws ForbiddenError when MEET_SYSTEM requests care_settings', async () => {
+    await expect(
+      enforceFieldAccess('MEET_SYSTEM', ['care_settings'])
+    ).rejects.toThrow(ForbiddenError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 8 — Cross-venue operator blocked (field-manifest level)
+// Complement to the RLS test: OPERATOR_PANEL blocked from individual user data.
+// ---------------------------------------------------------------------------
+describe('test_cross_venue_operator_blocked', () => {
+  it('throws ForbiddenError when OPERATOR_PANEL requests chat_content', async () => {
+    await expect(
+      enforceFieldAccess('OPERATOR_PANEL', ['chat_content'])
+    ).rejects.toThrow(ForbiddenError);
+  });
+
+  it('throws ForbiddenError when OPERATOR_PANEL requests meet_sessions', async () => {
+    await expect(
+      enforceFieldAccess('OPERATOR_PANEL', ['meet_sessions'])
+    ).rejects.toThrow(ForbiddenError);
+  });
+
+  it('unknown service throws ForbiddenError (fail-closed)', async () => {
+    await expect(
+      enforceFieldAccess('UNKNOWN_SERVICE', ['user_location'])
+    ).rejects.toThrow(ForbiddenError);
+    await expect(
+      enforceFieldAccess('UNKNOWN_SERVICE', ['user_location'])
+    ).rejects.toThrow(/Unknown service/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 9 — Malicious dev accidentally wires care context to AI
+// ---------------------------------------------------------------------------
+describe('test_malicious_dev_wires_care_to_ai', () => {
+  it('sanitiseForAI throws before the AI call when care_settings is present', async () => {
+    // Simulate a developer accidentally passing a full profile context to AI
+    const fullProfileContext = {
+      chat_text: 'where are you?',
+      meet_stage: 'finding',
+      care_settings: { get_out_enabled: true, land_time: '2026-05-01T03:00:00Z' },
+    };
+    await expect(sanitiseForAI(fullProfileContext)).rejects.toThrow(IsolationViolationError);
+    await expect(sanitiseForAI(fullProfileContext)).rejects.toThrow(
+      /Blocked field "care_settings" detected in AI context/
+    );
+  });
+
+  it('sanitiseForAI passes clean context through unmodified', async () => {
+    const cleanContext = {
+      chat_text:     'where are you?',
+      meet_stage:    'finding',
+      venue_context: 'Eagle Bar',
+    };
+    const result = await sanitiseForAI(cleanContext);
+    expect(result).toEqual(cleanContext);
+  });
+
+  it('all AI_BLOCKED_FIELDS trigger IsolationViolationError individually', async () => {
+    for (const field of AI_BLOCKED_FIELDS) {
+      const ctx = { [field]: 'test_value' };
+      await expect(sanitiseForAI(ctx)).rejects.toThrow(IsolationViolationError);
+    }
+  });
+});

--- a/supabase/migrations/20260501000003_v6_isolation_audit_log.sql
+++ b/supabase/migrations/20260501000003_v6_isolation_audit_log.sql
@@ -1,0 +1,127 @@
+-- HOTMESS v6 — Chunk 01: Runtime Isolation
+-- Migration: isolation_audit_log
+-- Spec: HOTMESS-RuntimeEnforcement.docx §8
+--
+-- Append-only log of every isolation violation.
+-- No UPDATE or DELETE ever. Alert fires on any row inserted.
+
+CREATE TABLE IF NOT EXISTS isolation_audit_log (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_type  TEXT        NOT NULL
+                CHECK (event_type IN (
+                  'BLOCKED_FIELD_ACCESS',
+                  'AI_BLOCKED_FIELD_DETECTED',
+                  'RLS_DENY'
+                )),
+  service     TEXT        NOT NULL,
+  field       TEXT        NOT NULL,
+  user_id     UUID,
+  request_id  TEXT,
+  stack_trace TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for weekly review queries
+CREATE INDEX IF NOT EXISTS idx_isolation_audit_event_type
+  ON isolation_audit_log (event_type);
+
+CREATE INDEX IF NOT EXISTS idx_isolation_audit_service
+  ON isolation_audit_log (service);
+
+CREATE INDEX IF NOT EXISTS idx_isolation_audit_created_at
+  ON isolation_audit_log (created_at DESC);
+
+-- RLS: enable row-level security
+ALTER TABLE isolation_audit_log ENABLE ROW LEVEL SECURITY;
+
+-- Authenticated users (service_role) can INSERT + SELECT.
+-- No UPDATE. No DELETE. Ever.
+CREATE POLICY "isolation_audit_service_insert"
+  ON isolation_audit_log
+  FOR INSERT
+  TO service_role
+  WITH CHECK (true);
+
+CREATE POLICY "isolation_audit_admin_select"
+  ON isolation_audit_log
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = auth.uid()
+      AND profiles.role = 'admin'
+    )
+  );
+
+-- Hard revoke UPDATE and DELETE for all roles
+REVOKE UPDATE ON isolation_audit_log FROM anon, authenticated, service_role;
+REVOKE DELETE ON isolation_audit_log FROM anon, authenticated, service_role;
+
+-- Operator RLS enforcement: block individual user data
+-- (Spec: HOTMESS-RuntimeEnforcement.docx §6)
+-- operator_role cannot read individual user location from profiles
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_roles WHERE rolname = 'operator_role'
+  ) THEN
+    CREATE ROLE operator_role;
+  END IF;
+END$$;
+
+-- Operator: no individual location
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'profiles'
+    AND policyname = 'operator_no_individual_location'
+  ) THEN
+    CREATE POLICY operator_no_individual_location ON profiles
+      FOR SELECT TO operator_role
+      USING (false);
+  END IF;
+END$$;
+
+-- Operator: revoke all on care tables (idempotent — tables may not exist yet)
+DO $$
+DECLARE
+  t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'support_preferences',
+    'lifestyle_preferences',
+    'backup_contacts',
+    'safety_alerts'
+  ] LOOP
+    IF EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = t
+    ) THEN
+      EXECUTE format('REVOKE ALL ON TABLE %I FROM operator_role', t);
+    END IF;
+  END LOOP;
+END$$;
+
+-- Venue aggregate stats view for operator_role
+-- (operators see aggregates, never individual records)
+-- Created only when meet_sessions table exists (Chunk 05 creates it).
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'meet_sessions'
+  ) THEN
+    EXECUTE $view$
+      CREATE OR REPLACE VIEW venue_aggregate_stats AS
+        SELECT
+          venue_id,
+          COUNT(*)          AS checkin_count,
+          MAX(created_at)   AS peak_time
+        FROM meet_sessions
+        GROUP BY venue_id
+    $view$;
+    EXECUTE 'GRANT SELECT ON venue_aggregate_stats TO operator_role';
+  END IF;
+END$$;


### PR DESCRIPTION
## Chunk 01: Runtime Isolation

**Spec:** HOTMESS-RuntimeEnforcement.docx + HOTMESS-SystemIsolationMap.docx
**Branch:** `feat/v6-01-isolation` → `feat/v6-spec-build`
**Feature flag:** none (infrastructure — always-on)

### What ships

| File | Purpose |
|------|--------|
| `src/lib/v6/fieldManifest.js` | FIELD_MANIFEST — per-service allowed/blocked field declarations. AI_LAYER, OPERATOR_PANEL, MEET_SYSTEM, NOTIFICATIONS, GLOBE_SYSTEM. AI_BLOCKED_FIELDS (12 fields). REALTIME_BLOCKED_TABLES (7 tables). |
| `src/lib/v6/isolationEnforcement.js` | `enforceFieldAccess(service, fields)` throws ForbiddenError. `sanitiseForAI(context)` throws IsolationViolationError, never strips. `logIsolationViolation()` append-only audit write. |
| `src/test/isolationEnforcement.test.js` | All 9 spec-mandated isolation tests. |
| `supabase/migrations/20260501000003_v6_isolation_audit_log.sql` | `isolation_audit_log` table — append-only, UPDATE/DELETE revoked. `operator_role` created. RLS blocking operator from individual user data. |

### 9 isolation tests (any failure = deploy blocked)
- `test_ai_cannot_read_support_prefs`
- `test_ai_cannot_read_lifestyle_flags`
- `test_operator_cannot_read_user_location`
- `test_operator_cannot_read_care_data`
- `test_care_event_not_in_realtime`
- `test_notifications_blocks_lifestyle`
- `test_meet_system_blocks_care_fields`
- `test_cross_venue_operator_blocked`
- `test_malicious_dev_wires_care_to_ai`

### DB changes (applied ✅)
- New table: `isolation_audit_log` (append-only, admin-only SELECT)
- New role: `operator_role` (blocked from all individual user data)

### Rollback
No flag — infra chunk. `git revert -m 1 <merge-sha>`

### Phils done-checklist
- [ ] CI shows 9/9 isolation tests passing
- [ ] Test: AI request with blocked field → IsolationViolationError thrown, audit log row appears
- [ ] Side-by-side: zero user-visible difference (pure infra)