### PR TITLE
feat(v6-02): Support Proximity — schema, privacy, UI [behind flag]

### DIFF
--- a/api/profile.js
+++ b/api/profile.js
@@ -152,9 +152,11 @@ export default async function handler(req, res) {
 
   const { error: supaErr, serviceClient, anonClient } = getSupabaseServerClients();
 
+  let requesterAuthId = null;
   if (accessToken && anonClient) {
-    const { data, error } = await anonClient.auth.getUser(accessToken);
+    const { data: _authRes } = await anonClient.auth.getUser(accessToken);
     // Token validation is optional - profile viewing works without auth via RLS
+    requesterAuthId = _authRes?.user?.id ?? null;
   }
 
   // If service role isn't configured (common in local dev), try an authenticated anon-client query
@@ -215,6 +217,18 @@ export default async function handler(req, res) {
 
   let sawMissingTable = false;
 
+  // v6 Chunk 02: strip lifestyle_preferences + support_preferences for non-owner views
+  // DECOUPLING RULE: these fields are private regardless of lifestyle_preferences content.
+  const stripPrivateForNonOwner = (r) => {
+    if (!r) return r;
+    const isOwner = !!requesterAuthId && requesterAuthId === r?.auth_user_id;
+    if (isOwner) return r;
+    const out = { ...r };
+    delete out.lifestyle_preferences;
+    delete out.support_preferences;
+    return out;
+  };
+
   const respondWithUser = async (row) => {
     // Fetch profile_photos for this user (canonical multi-photo table)
     let profilePhotos = [];
@@ -241,7 +255,7 @@ export default async function handler(req, res) {
     const authUserId = row?.auth_user_id ? String(row.auth_user_id).trim() : null;
     if (!authUserId || !serviceClient?.auth?.admin?.getUserById) {
       // GDPR: strip email from response — never expose to other users
-      const { email: _email, user_email: _ue, ...safe } = enrichRow(row) || {};
+      const { email: _email, user_email: _ue, ...safe } = stripPrivateForNonOwner(enrichRow(row)) || {};
       return json(res, 200, { user: safe });
     }
 
@@ -250,11 +264,11 @@ export default async function handler(req, res) {
       const meta = error ? null : (data?.user?.user_metadata || null);
       const merged = mergeAuthMeta({ row, meta });
       // GDPR: strip email from response — never expose to other users
-      const { email: _email, user_email: _ue, ...safe } = enrichRow(merged) || {};
+      const { email: _email, user_email: _ue, ...safe } = stripPrivateForNonOwner(enrichRow(merged)) || {};
       return json(res, 200, { user: safe });
     } catch {
       // GDPR: strip email from response — never expose to other users
-      const { email: _email, user_email: _ue, ...safe } = enrichRow(row) || {};
+      const { email: _email, user_email: _ue, ...safe } = stripPrivateForNonOwner(enrichRow(row)) || {};
       return json(res, 200, { user: safe });
     }
   };

--- a/api/support/sync-meetings.js
+++ b/api/support/sync-meetings.js
@@ -1,0 +1,203 @@
+/**
+ * HOTMESS v6 — Support Proximity: Meeting Sync
+ * api/support/sync-meetings.js
+ *
+ * Fetches AA/NA meetings from TSML-format sources and upserts into support_meetings.
+ * Focused on London (lat 51.5074, lng -0.1278), radius 15km.
+ *
+ * Sources (in priority order):
+ *   1. London Intergroup AA (TSML WordPress API)
+ *   2. AA Great Britain national (TSML)
+ *   3. NA UK (TSML)
+ *
+ * TSML spec: https://code4recovery.github.io/spec/
+ * Day format: 0=Sunday … 6=Saturday (matches our schema)
+ *
+ * Auth: CRON_SECRET header — same as other crons.
+ * Called by: vercel.json cron + admin POST
+ *
+ * PRIVACY: no user data involved. Meeting data is public directory information.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+// ── London bounding box (±15km) ───────────────────────────────────────────────
+const LONDON_LAT  = 51.5074;
+const LONDON_LNG  = -0.1278;
+const RADIUS_KM   = 15;
+
+// ── TSML sources — ordered by coverage quality for London ────────────────────
+const TSML_SOURCES = [
+  {
+    url:  'https://londonintergroup.co.uk/wp-json/tsml/v1/meetings',
+    type: 'aa',
+    name: 'AA London Intergroup',
+  },
+  {
+    url:  'https://www.alcoholicsanonymous.org.uk/wp-json/tsml/v1/meetings',
+    type: 'aa',
+    name: 'AA Great Britain',
+  },
+  {
+    url:  'https://www.ukna.org/wp-json/tsml/v1/meetings',
+    type: 'na',
+    name: 'NA UK',
+  },
+];
+
+// ── Haversine distance (km) ───────────────────────────────────────────────────
+function distanceKm(lat1, lng1, lat2, lng2) {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+// ── TSML → support_meetings row ──────────────────────────────────────────────
+function tsmlToRow(meeting, sourceType) {
+  const lat = parseFloat(meeting.latitude  ?? meeting.lat ?? '');
+  const lng = parseFloat(meeting.longitude ?? meeting.lng ?? '');
+  if (isNaN(lat) || isNaN(lng)) return null;
+  if (distanceKm(LONDON_LAT, LONDON_LNG, lat, lng) > RADIUS_KM) return null;
+
+  // TSML day: 0=Sunday … 6=Saturday — same as our schema
+  const dayRaw = parseInt(meeting.day ?? meeting.day_of_week ?? '', 10);
+  if (isNaN(dayRaw) || dayRaw < 0 || dayRaw > 6) return null;
+
+  // TSML time: "HH:MM" or "HH:MM:SS"
+  const timeRaw = String(meeting.time ?? meeting.start_time ?? '').trim();
+  if (!timeRaw || !/^\d{2}:\d{2}/.test(timeRaw)) return null;
+  const start_time = timeRaw.length === 5 ? `${timeRaw}:00` : timeRaw;
+
+  // Infer meeting_type from TSML types array or source
+  const types = Array.isArray(meeting.types) ? meeting.types.map(t => String(t).toUpperCase()) : [];
+  let meeting_type = sourceType; // 'aa' or 'na' from source config
+  if (types.some(t => t === 'NA' || t.includes('NARCOTIC'))) meeting_type = 'na';
+  if (types.some(t => t === 'AA' || t.includes('ALCOHOL')))  meeting_type = 'aa';
+
+  return {
+    // Stable external ID: use TSML slug or name+day+time combo
+    external_id:  String(meeting.slug ?? meeting.id ?? `${meeting.name}-${dayRaw}-${timeRaw}`),
+    meeting_type,
+    name:        String(meeting.name ?? meeting.meeting ?? '').slice(0, 200) || null,
+    lat:         lat.toFixed(6),
+    lng:         lng.toFixed(6),
+    day_of_week: dayRaw,
+    start_time,
+    is_active:   true,
+  };
+}
+
+// ── Fetch one TSML source with timeout ───────────────────────────────────────
+async function fetchTsmlSource(source) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15_000);
+  try {
+    const res = await fetch(source.url, {
+      signal: controller.signal,
+      headers: { Accept: 'application/json', 'User-Agent': 'HOTMESS-MeetingSync/1.0' },
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    // TSML returns array directly or { meetings: [...] }
+    const meetings = Array.isArray(data) ? data : (data.meetings ?? []);
+    return { source: source.name, meetings, error: null };
+  } catch (err) {
+    return { source: source.name, meetings: [], error: err.message };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// ── Main handler ──────────────────────────────────────────────────────────────
+export default async function handler(req, res) {
+  // Auth: cron secret or admin POST
+  const secret = req.headers['x-cron-secret'] ?? req.headers['authorization']?.replace('Bearer ', '');
+  if (secret !== process.env.CRON_SECRET) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const supabaseUrl = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL;
+  const serviceKey  = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceKey) {
+    return res.status(500).json({ error: 'Missing Supabase credentials' });
+  }
+
+  const supabase = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false },
+  });
+
+  const results = { sources: [], inserted: 0, updated: 0, skipped: 0, errors: [] };
+
+  // Fetch all sources in parallel
+  const fetches = await Promise.all(TSML_SOURCES.map(fetchTsmlSource));
+
+  // Deduplicate across sources by external_id
+  const rowMap = new Map();
+  for (const { source, meetings, error } of fetches) {
+    if (error) {
+      results.errors.push(`${source}: ${error}`);
+      results.sources.push({ source, count: 0, error });
+      continue;
+    }
+
+    let count = 0;
+    const sourceType = TSML_SOURCES.find(s => s.name === source)?.type ?? 'other';
+    for (const m of meetings) {
+      const row = tsmlToRow(m, sourceType);
+      if (!row) continue;
+      if (!rowMap.has(row.external_id)) {
+        rowMap.set(row.external_id, row);
+        count++;
+      }
+    }
+    results.sources.push({ source, count, error: null });
+  }
+
+  const rows = Array.from(rowMap.values());
+
+  if (rows.length === 0) {
+    return res.status(200).json({
+      ok: true,
+      message: 'No meetings found within radius — sources may be down',
+      ...results,
+    });
+  }
+
+  // Upsert in batches of 100
+  // external_id column needed — add it if not present (migration adds it)
+  const BATCH = 100;
+  for (let i = 0; i < rows.length; i += BATCH) {
+    const batch = rows.slice(i, i + BATCH);
+    const { error } = await supabase
+      .from('support_meetings')
+      .upsert(batch, { onConflict: 'external_id', ignoreDuplicates: false });
+    if (error) {
+      results.errors.push(`upsert batch ${i / BATCH}: ${error.message}`);
+    } else {
+      results.inserted += batch.length;
+    }
+  }
+
+  // Mark meetings not in this sync as inactive (stale data)
+  const activeIds = rows.map(r => r.external_id);
+  if (activeIds.length > 0) {
+    const { error: deactivateErr } = await supabase
+      .from('support_meetings')
+      .update({ is_active: false })
+      .not('external_id', 'in', `(${activeIds.map(id => `'${id.replace(/'/g, "''")}'`).join(',')})`)
+      .eq('is_active', true);
+    if (deactivateErr) results.errors.push(`deactivate stale: ${deactivateErr.message}`);
+  }
+
+  return res.status(200).json({
+    ok: results.errors.length === 0,
+    total_rows: rows.length,
+    ...results,
+  });
+}

--- a/src/components/settings/CareSettings.jsx
+++ b/src/components/settings/CareSettings.jsx
@@ -1,0 +1,250 @@
+/**
+ * HOTMESS v6 — Care Settings
+ * Spec: DEV_BRIEF_support-proximity.docx §5
+ *
+ * Entry point: Settings > Care
+ * Default: OFF
+ * Behind flag: v6_support_proximity_ui
+ *
+ * UI CONSTRAINTS — from spec:
+ * - Toggle: "Notify me about nearby support meetings" | Default: OFF
+ * - Sub-option (visible when enabled): Detail level generic | detailed
+ * - DO NOT add to: chat, meet flow, Globe, discovery, push settings, any AI surface
+ */
+
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useV6Flag } from '@/hooks/useV6Flag';
+import { getSupportPreferences, setSupportEnabled, setSupportDetailLevel } from '@/lib/v6/supportProximity';
+
+export default function CareSettings() {
+  const { user } = useAuth();
+  const flagOn = useV6Flag('v6_support_proximity_ui');
+
+  const [enabled, setEnabled] = useState(false);
+  const [detailLevel, setDetailLevel] = useState('generic');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!user?.id || !flagOn) return;
+    getSupportPreferences(user.id).then(prefs => {
+      if (prefs?.support) {
+        setEnabled(prefs.support.support_notifications_enabled ?? false);
+        setDetailLevel(prefs.support.support_detail_level ?? 'generic');
+      }
+      setLoading(false);
+    });
+  }, [user?.id, flagOn]);
+
+  // Flag off → render nothing (spec: "If not explicitly enabled it does not exist")
+  if (!flagOn) return null;
+  if (loading) return null;
+
+  const handleToggle = async () => {
+    const next = !enabled;
+    setEnabled(next);
+    setSaving(true);
+    await setSupportEnabled(user.id, next);
+    setSaving(false);
+  };
+
+  const handleDetailLevel = async (level) => {
+    setDetailLevel(level);
+    setSaving(true);
+    await setSupportDetailLevel(user.id, level);
+    setSaving(false);
+  };
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.section}>
+        <p style={styles.sectionLabel}>SUPPORT</p>
+
+        {/* Primary toggle */}
+        <div style={styles.row}>
+          <div style={styles.rowText}>
+            <span style={styles.rowTitle}>Nearby support</span>
+            <span style={styles.rowSub}>
+              Get a quiet notification when a support meeting is nearby
+            </span>
+          </div>
+          <button
+            style={{ ...styles.toggle, ...(enabled ? styles.toggleOn : styles.toggleOff) }}
+            onClick={handleToggle}
+            disabled={saving}
+            aria-label="Toggle nearby support notifications"
+          >
+            <div style={{ ...styles.toggleKnob, ...(enabled ? styles.knobOn : styles.knobOff) }} />
+          </button>
+        </div>
+
+        {/* Detail level — only shown when enabled */}
+        {enabled && (
+          <div style={styles.subOption}>
+            <p style={styles.subLabel}>Notification detail</p>
+            <div style={styles.radioGroup}>
+              <button
+                style={{ ...styles.radioOption, ...(detailLevel === 'generic' ? styles.radioSelected : {}) }}
+                onClick={() => handleDetailLevel('generic')}
+                disabled={saving}
+              >
+                <div style={styles.radioIndicator}>
+                  {detailLevel === 'generic' && <div style={styles.radioDot} />}
+                </div>
+                <div>
+                  <span style={styles.radioTitle}>General</span>
+                  <span style={styles.radioExample}>"Support nearby tonight · 10 min away"</span>
+                </div>
+              </button>
+
+              <button
+                style={{ ...styles.radioOption, ...(detailLevel === 'detailed' ? styles.radioSelected : {}) }}
+                onClick={() => handleDetailLevel('detailed')}
+                disabled={saving}
+              >
+                <div style={styles.radioIndicator}>
+                  {detailLevel === 'detailed' && <div style={styles.radioDot} />}
+                </div>
+                <div>
+                  <span style={styles.radioTitle}>Specific</span>
+                  <span style={styles.radioExample}>"AA / NA meeting nearby · 10 min away"</span>
+                </div>
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Styles — HOTMESS brand: dark bg, gold accent, no light mode ───────────────
+const styles = {
+  container: {
+    background: '#050507',
+    color: '#FFFFFF',
+    padding: '0 16px',
+  },
+  section: {
+    paddingTop: 24,
+    paddingBottom: 8,
+  },
+  sectionLabel: {
+    fontSize: 11,
+    fontWeight: 600,
+    letterSpacing: '0.1em',
+    color: '#666',
+    textTransform: 'uppercase',
+    margin: '0 0 16px 0',
+  },
+  row: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '14px 0',
+    borderBottom: '1px solid #111',
+  },
+  rowText: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 4,
+    flex: 1,
+    paddingRight: 16,
+  },
+  rowTitle: {
+    fontSize: 15,
+    fontWeight: 500,
+    color: '#FFFFFF',
+  },
+  rowSub: {
+    fontSize: 13,
+    color: '#666',
+    lineHeight: 1.4,
+  },
+  toggle: {
+    position: 'relative',
+    width: 44,
+    height: 26,
+    borderRadius: 13,
+    border: 'none',
+    cursor: 'pointer',
+    flexShrink: 0,
+    transition: 'background 0.2s',
+    padding: 0,
+  },
+  toggleOn:  { background: '#C8962C' },
+  toggleOff: { background: '#333' },
+  toggleKnob: {
+    position: 'absolute',
+    top: 3,
+    width: 20,
+    height: 20,
+    borderRadius: '50%',
+    background: '#FFFFFF',
+    transition: 'left 0.2s',
+  },
+  knobOn:  { left: 21 },
+  knobOff: { left: 3 },
+  subOption: {
+    paddingTop: 16,
+    paddingBottom: 8,
+  },
+  subLabel: {
+    fontSize: 12,
+    color: '#666',
+    margin: '0 0 12px 0',
+    textTransform: 'uppercase',
+    letterSpacing: '0.08em',
+  },
+  radioGroup: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8,
+  },
+  radioOption: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: 12,
+    padding: '12px 14px',
+    background: '#0E0E10',
+    border: '1px solid #1A1A1C',
+    borderRadius: 8,
+    cursor: 'pointer',
+    textAlign: 'left',
+    transition: 'border-color 0.15s',
+  },
+  radioSelected: {
+    borderColor: '#C8962C',
+  },
+  radioIndicator: {
+    width: 18,
+    height: 18,
+    borderRadius: '50%',
+    border: '2px solid #444',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    marginTop: 1,
+  },
+  radioDot: {
+    width: 8,
+    height: 8,
+    borderRadius: '50%',
+    background: '#C8962C',
+  },
+  radioTitle: {
+    display: 'block',
+    fontSize: 14,
+    fontWeight: 500,
+    color: '#FFF',
+    marginBottom: 2,
+  },
+  radioExample: {
+    display: 'block',
+    fontSize: 12,
+    color: '#555',
+    fontStyle: 'italic',
+  },
+};

--- a/src/lib/v6/supportProximity.js
+++ b/src/lib/v6/supportProximity.js
@@ -41,21 +41,13 @@ export async function getSupportPreferences(userId) {
 // ── Update support preferences (own profile only) ────────────────────────────
 export async function setSupportEnabled(userId, enabled) {
   if (!userId) return;
-  const { error } = await supabase
-    .from('profiles')
-    .update({
-      support_preferences: supabase.rpc ? undefined : {},  // handled below
-    })
-    .eq('id', userId);
-
-  // Use jsonb_set pattern via RPC for safe partial update
-  const { error: rpcError } = await supabase.rpc('update_support_preferences', {
+  // Safe partial JSONB update via RPC — never overwrites other support_preferences fields
+  const { error } = await supabase.rpc('update_support_preferences', {
     p_user_id: userId,
     p_enabled: enabled,
     p_detail_level: null,  // null = don't change
   });
-
-  return rpcError;
+  return error;
 }
 
 export async function setSupportDetailLevel(userId, level) {

--- a/src/lib/v6/supportProximity.js
+++ b/src/lib/v6/supportProximity.js
@@ -1,0 +1,163 @@
+/**
+ * HOTMESS v6 — Support Proximity: Helpers
+ * Spec: DEV_BRIEF_support-proximity.docx
+ *
+ * CORE RULE: If support_notifications_enabled is false, this module
+ * does nothing. No processing, no scheduling, no logs. Total silence.
+ *
+ * DECOUPLING RULE: lifestyle_preferences has zero effect here.
+ * Only support_preferences.support_notifications_enabled activates the system.
+ */
+
+import { supabase } from '@/lib/supabase';
+
+// ── Private field names — stripped from non-owner API responses ───────────────
+export const SUPPORT_PRIVATE_FIELDS = [
+  'lifestyle_preferences',
+  'support_preferences',
+];
+
+// ── Notification copy — exact, no variations ─────────────────────────────────
+export const SUPPORT_NOTIFICATION_COPY = {
+  generic:  'Support nearby tonight · 10 min away',
+  detailed: 'AA / NA meeting nearby · 10 min away',
+};
+
+// ── Read own support preferences ─────────────────────────────────────────────
+export async function getSupportPreferences(userId) {
+  if (!userId) return null;
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('support_preferences, lifestyle_preferences')
+    .eq('id', userId)
+    .single();
+  if (error || !data) return null;
+  return {
+    support: data.support_preferences ?? { support_notifications_enabled: false, support_detail_level: 'generic' },
+    lifestyle: data.lifestyle_preferences ?? null,
+  };
+}
+
+// ── Update support preferences (own profile only) ────────────────────────────
+export async function setSupportEnabled(userId, enabled) {
+  if (!userId) return;
+  const { error } = await supabase
+    .from('profiles')
+    .update({
+      support_preferences: supabase.rpc ? undefined : {},  // handled below
+    })
+    .eq('id', userId);
+
+  // Use jsonb_set pattern via RPC for safe partial update
+  const { error: rpcError } = await supabase.rpc('update_support_preferences', {
+    p_user_id: userId,
+    p_enabled: enabled,
+    p_detail_level: null,  // null = don't change
+  });
+
+  return rpcError;
+}
+
+export async function setSupportDetailLevel(userId, level) {
+  if (!userId || !['generic', 'detailed'].includes(level)) return;
+  const { error } = await supabase.rpc('update_support_preferences', {
+    p_user_id: userId,
+    p_enabled: null,       // null = don't change
+    p_detail_level: level,
+  });
+  return error;
+}
+
+// ── Update lifestyle preferences (own profile only, declarative only) ─────────
+export async function setLifestylePreferences(userId, prefs) {
+  if (!userId || !prefs) return;
+  // NEVER trigger any system behaviour here.
+  // Write the tag. That is all.
+  const { error } = await supabase
+    .from('profiles')
+    .update({ lifestyle_preferences: prefs })
+    .eq('id', userId);
+  return error;
+}
+
+// ── Strip private fields from a profile object for non-owner views ────────────
+export function stripSupportFields(profileRow) {
+  if (!profileRow) return profileRow;
+  const safe = { ...profileRow };
+  delete safe.lifestyle_preferences;
+  delete safe.support_preferences;
+  return safe;
+}
+
+// ── Check if user is within proximity of any active support meeting ───────────
+// Returns { nearby: boolean, meeting: object|null } — uses broad radius (2km).
+// Approximate location only. No exact coordinates stored.
+export async function checkSupportProximity(userId, approxLat, approxLng) {
+  // First: bail immediately if not enabled
+  const prefs = await getSupportPreferences(userId);
+  if (!prefs?.support?.support_notifications_enabled) {
+    return { nearby: false, meeting: null };
+  }
+
+  // Check if already notified in this window
+  const windowKey = _currentWindowKey();
+  const { data: existing } = await supabase
+    .from('support_notification_log')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('window_key', windowKey)
+    .maybeSingle();
+
+  if (existing) return { nearby: false, meeting: null, suppressed: true };
+
+  // Broad radius check — 2km, approximate only
+  const RADIUS_KM = 2;
+  const now = new Date();
+  const currentTime = `${String(now.getHours()).padStart(2,'0')}:${String(now.getMinutes()).padStart(2,'0')}:00`;
+  const dayOfWeek = now.getDay();
+
+  const { data: meetings } = await supabase
+    .from('support_meetings')
+    .select('id, meeting_type, name, lat, lng, start_time')
+    .eq('is_active', true)
+    .eq('day_of_week', dayOfWeek);
+
+  if (!meetings?.length) return { nearby: false, meeting: null };
+
+  // Filter by approximate distance
+  const nearby = meetings.find(m => {
+    const distKm = _approxDistanceKm(approxLat, approxLng, Number(m.lat), Number(m.lng));
+    const minutesUntil = _minutesUntilMeeting(currentTime, m.start_time);
+    return distKm <= RADIUS_KM && minutesUntil >= 0 && minutesUntil <= 120;
+  });
+
+  return { nearby: !!nearby, meeting: nearby ?? null };
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+function _currentWindowKey() {
+  const now = new Date();
+  const date = now.toISOString().split('T')[0];
+  const hour = now.getHours();
+  const slot = hour < 12 ? 'morning' : hour < 18 ? 'afternoon' : 'evening';
+  return `${date}-${slot}`;
+}
+
+function _approxDistanceKm(lat1, lng1, lat2, lng2) {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function _minutesUntilMeeting(currentTimeStr, meetingTimeStr) {
+  const [ch, cm] = currentTimeStr.split(':').map(Number);
+  const [mh, mm] = meetingTimeStr.split(':').map(Number);
+  return (mh * 60 + mm) - (ch * 60 + cm);
+}

--- a/src/test/supportProximity.test.js
+++ b/src/test/supportProximity.test.js
@@ -1,0 +1,415 @@
+/**
+ * HOTMESS v6 — Chunk 02: Support Proximity Tests
+ *
+ * Spec: DEV_BRIEF_support-proximity.docx
+ *
+ * Tests:
+ *  1. getSupportPreferences returns correct shape
+ *  2. getSupportPreferences returns null on DB error
+ *  3. setSupportEnabled calls RPC with correct args
+ *  4. setSupportDetailLevel rejects invalid level
+ *  5. setLifestylePreferences writes tag only — does NOT call proximity RPC
+ *  6. checkSupportProximity bails immediately if support_notifications_enabled = false
+ *  7. checkSupportProximity suppresses when already notified in window
+ *  8. checkSupportProximity returns nearby=true within 2km + 2hr window
+ *  9. checkSupportProximity returns nearby=false outside 2km radius
+ * 10. stripSupportFields removes both private fields
+ * 11. stripSupportFields leaves everything else intact
+ * 12. DECOUPLING: lifestyle_preferences change does NOT trigger checkSupportProximity
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock Supabase ──────────────────────────────────────────────────────────────
+const mockSelect  = vi.fn();
+const mockEq      = vi.fn();
+const mockUpdate  = vi.fn();
+const mockInsert  = vi.fn();
+const mockRpc     = vi.fn();
+const mockSingle  = vi.fn();
+const mockMaybeSingle = vi.fn();
+
+const mockFrom = vi.fn(() => ({
+  select:      mockSelect,
+  update:      mockUpdate,
+  insert:      mockInsert,
+  eq:          mockEq,
+  maybeSingle: mockMaybeSingle,
+  single:      mockSingle,
+}));
+
+// Chain helpers — each returns the chain object so calls compose
+const chainObj = {
+  select:      (...a) => { mockSelect(...a);      return chainObj; },
+  eq:          (...a) => { mockEq(...a);           return chainObj; },
+  update:      (...a) => { mockUpdate(...a);        return chainObj; },
+  insert:      (...a) => { mockInsert(...a);        return chainObj; },
+  maybeSingle: (...a) => { mockMaybeSingle(...a);  return chainObj; },
+  single:      (...a) => { mockSingle(...a);        return chainObj; },
+};
+
+let _fromImpl = () => chainObj;
+let _rpcImpl  = () => ({ data: null, error: null });
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    from: (...a) => _fromImpl(...a),
+    rpc:  (...a) => _rpcImpl(...a),
+  })),
+}));
+
+// ── Import module under test ──────────────────────────────────────────────────
+import {
+  getSupportPreferences,
+  setSupportEnabled,
+  setSupportDetailLevel,
+  setLifestylePreferences,
+  checkSupportProximity,
+  stripSupportFields,
+  SUPPORT_NOTIFICATION_COPY,
+} from '../lib/v6/supportProximity.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+const USER_ID = '302040e5-c2ac-4fb3-a192-70598aa7b962';
+const ENABLED_PREFS = {
+  support_notifications_enabled: true,
+  support_detail_level: 'generic',
+};
+const DISABLED_PREFS = {
+  support_notifications_enabled: false,
+  support_detail_level: 'generic',
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function mockProfileRow(supportPrefs = ENABLED_PREFS, lifestylePrefs = null) {
+  return {
+    support_preferences:  supportPrefs,
+    lifestyle_preferences: lifestylePrefs,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('getSupportPreferences', () => {
+  it('test_get_prefs_returns_correct_shape', async () => {
+    _fromImpl = () => ({
+      select:      () => ({
+        eq:          () => ({
+          single:      () => Promise.resolve({ data: mockProfileRow(), error: null }),
+          maybeSingle: () => Promise.resolve({ data: mockProfileRow(), error: null }),
+        }),
+      }),
+    });
+
+    const result = await getSupportPreferences(USER_ID);
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('support');
+    expect(result.support).toHaveProperty('support_notifications_enabled');
+    expect(result.support).toHaveProperty('support_detail_level');
+  });
+
+  it('test_get_prefs_returns_null_on_error', async () => {
+    _fromImpl = () => ({
+      select: () => ({
+        eq: () => ({
+          single:      () => Promise.resolve({ data: null, error: new Error('DB down') }),
+          maybeSingle: () => Promise.resolve({ data: null, error: new Error('DB down') }),
+        }),
+      }),
+    });
+
+    const result = await getSupportPreferences(USER_ID);
+    expect(result).toBeNull();
+  });
+
+  it('test_get_prefs_returns_null_for_missing_userId', async () => {
+    const result = await getSupportPreferences(null);
+    expect(result).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('setSupportEnabled', () => {
+  it('test_set_enabled_calls_rpc_with_correct_args', async () => {
+    const rpcCalls = [];
+    _rpcImpl = (name, args) => {
+      rpcCalls.push({ name, args });
+      return Promise.resolve({ data: null, error: null });
+    };
+
+    await setSupportEnabled(USER_ID, true);
+
+    const rpcCall = rpcCalls.find(c => c.name === 'update_support_preferences');
+    expect(rpcCall).toBeDefined();
+    expect(rpcCall.args.p_user_id).toBe(USER_ID);
+    expect(rpcCall.args.p_enabled).toBe(true);
+    expect(rpcCall.args.p_detail_level).toBeNull(); // null = don't change
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('setSupportDetailLevel', () => {
+  it('test_set_detail_level_valid_values', async () => {
+    const rpcCalls = [];
+    _rpcImpl = (name, args) => {
+      rpcCalls.push({ name, args });
+      return Promise.resolve({ data: null, error: null });
+    };
+
+    await setSupportDetailLevel(USER_ID, 'detailed');
+    await setSupportDetailLevel(USER_ID, 'generic');
+
+    expect(rpcCalls.length).toBe(2);
+    expect(rpcCalls[0].args.p_detail_level).toBe('detailed');
+    expect(rpcCalls[1].args.p_detail_level).toBe('generic');
+  });
+
+  it('test_set_detail_level_rejects_invalid_level', async () => {
+    const rpcCalls = [];
+    _rpcImpl = (name, args) => { rpcCalls.push({ name, args }); return Promise.resolve({}); };
+
+    // Should return early — invalid level
+    await setSupportDetailLevel(USER_ID, 'aa_specific');
+    await setSupportDetailLevel(USER_ID, '');
+    await setSupportDetailLevel(USER_ID, null);
+
+    expect(rpcCalls.length).toBe(0); // no RPC called
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('setLifestylePreferences — DECOUPLING RULE', () => {
+  it('test_lifestyle_write_does_not_call_support_rpc', async () => {
+    const rpcCalls = [];
+    _rpcImpl = (name, args) => {
+      rpcCalls.push({ name, args });
+      return Promise.resolve({ data: null, error: null });
+    };
+
+    const updateCalls = [];
+    _fromImpl = () => ({
+      update: (data) => {
+        updateCalls.push(data);
+        return { eq: () => Promise.resolve({ error: null }) };
+      },
+    });
+
+    // Set lifestyle prefs (sober flag, etc.)
+    await setLifestylePreferences(USER_ID, { sober: true, recovery: true });
+
+    // CRITICAL: must NOT have called update_support_preferences or checkSupportProximity
+    const supportRpc = rpcCalls.find(c => c.name === 'update_support_preferences');
+    expect(supportRpc).toBeUndefined();
+
+    // Must have written lifestyle_preferences
+    const lifestyleUpdate = updateCalls.find(d => 'lifestyle_preferences' in d);
+    expect(lifestyleUpdate).toBeDefined();
+    expect(lifestyleUpdate.lifestyle_preferences).toMatchObject({ sober: true, recovery: true });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('checkSupportProximity', () => {
+  it('test_bails_immediately_if_notifications_disabled', async () => {
+    _fromImpl = () => ({
+      select: () => ({
+        eq: () => ({
+          single:      () => Promise.resolve({ data: { support_preferences: DISABLED_PREFS, lifestyle_preferences: null }, error: null }),
+          maybeSingle: () => Promise.resolve({ data: { support_preferences: DISABLED_PREFS, lifestyle_preferences: null }, error: null }),
+        }),
+      }),
+    });
+
+    const result = await checkSupportProximity(USER_ID, 51.5074, -0.1278);
+    expect(result.nearby).toBe(false);
+    expect(result.meeting).toBeNull();
+  });
+
+  it('test_suppresses_if_already_notified_in_window', async () => {
+    let callCount = 0;
+    _fromImpl = (table) => {
+      callCount++;
+      if (table === 'profiles') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single:      () => Promise.resolve({ data: { support_preferences: ENABLED_PREFS, lifestyle_preferences: null }, error: null }),
+              maybeSingle: () => Promise.resolve({ data: { support_preferences: ENABLED_PREFS, lifestyle_preferences: null }, error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === 'support_notification_log') {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                maybeSingle: () => Promise.resolve({ data: { id: 'existing-log' }, error: null }),
+              }),
+            }),
+          }),
+        };
+      }
+      return { select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: null }) }) }) };
+    };
+
+    const result = await checkSupportProximity(USER_ID, 51.5074, -0.1278);
+    expect(result.nearby).toBe(false);
+    expect(result.suppressed).toBe(true);
+  });
+
+  it('test_returns_nearby_true_within_2km', async () => {
+    const now = new Date();
+    const futureHour = (now.getHours() + 1) % 24;
+    const meetingTime = `${String(futureHour).padStart(2,'0')}:00:00`;
+
+    _fromImpl = (table) => {
+      if (table === 'profiles') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single:      () => Promise.resolve({ data: { support_preferences: ENABLED_PREFS }, error: null }),
+              maybeSingle: () => Promise.resolve({ data: { support_preferences: ENABLED_PREFS }, error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === 'support_notification_log') {
+        return {
+          select: () => ({ eq: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: null }) }) }) }),
+        };
+      }
+      if (table === 'support_meetings') {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => Promise.resolve({
+                data: [{
+                  id: 'meeting-1',
+                  meeting_type: 'aa',
+                  name: 'Test Meeting',
+                  lat: '51.5080', // ~0.7km from 51.5074,-0.1278
+                  lng: '-0.1285',
+                  start_time: meetingTime,
+                }],
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      return { select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: null }) }) }) };
+    };
+
+    const result = await checkSupportProximity(USER_ID, 51.5074, -0.1278);
+    expect(result.nearby).toBe(true);
+    expect(result.meeting).not.toBeNull();
+  });
+
+  it('test_returns_nearby_false_outside_2km', async () => {
+    const now = new Date();
+    const futureHour = (now.getHours() + 1) % 24;
+    const meetingTime = `${String(futureHour).padStart(2,'0')}:00:00`;
+
+    _fromImpl = (table) => {
+      if (table === 'profiles') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single:      () => Promise.resolve({ data: { support_preferences: ENABLED_PREFS }, error: null }),
+              maybeSingle: () => Promise.resolve({ data: { support_preferences: ENABLED_PREFS }, error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === 'support_notification_log') {
+        return {
+          select: () => ({ eq: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: null }) }) }) }),
+        };
+      }
+      if (table === 'support_meetings') {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => Promise.resolve({
+                data: [{
+                  id: 'meeting-far',
+                  meeting_type: 'na',
+                  lat: '51.5500', // ~5km away
+                  lng: '-0.1278',
+                  start_time: meetingTime,
+                }],
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      return { select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: null }) }) }) };
+    };
+
+    const result = await checkSupportProximity(USER_ID, 51.5074, -0.1278);
+    expect(result.nearby).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('stripSupportFields', () => {
+  it('test_strips_both_private_fields', () => {
+    const row = {
+      id: 'abc',
+      display_name: 'Jay',
+      lifestyle_preferences: { sober: true },
+      support_preferences: { support_notifications_enabled: true, support_detail_level: 'generic' },
+      city: 'London',
+    };
+
+    const safe = stripSupportFields(row);
+    expect(safe).not.toHaveProperty('lifestyle_preferences');
+    expect(safe).not.toHaveProperty('support_preferences');
+  });
+
+  it('test_strips_leaves_other_fields_intact', () => {
+    const row = {
+      id: 'abc',
+      display_name: 'Jay',
+      lifestyle_preferences: { sober: true },
+      support_preferences: { support_notifications_enabled: false },
+      city: 'London',
+      avatar_url: 'https://example.com/img.jpg',
+    };
+
+    const safe = stripSupportFields(row);
+    expect(safe.id).toBe('abc');
+    expect(safe.display_name).toBe('Jay');
+    expect(safe.city).toBe('London');
+    expect(safe.avatar_url).toBe('https://example.com/img.jpg');
+  });
+
+  it('test_strips_handles_null_row', () => {
+    expect(stripSupportFields(null)).toBeNull();
+    expect(stripSupportFields(undefined)).toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('SUPPORT_NOTIFICATION_COPY', () => {
+  it('test_notification_copy_exact_spec_values', () => {
+    // Exact copy per spec — must not vary
+    expect(SUPPORT_NOTIFICATION_COPY.generic).toBe('Support nearby tonight · 10 min away');
+    expect(SUPPORT_NOTIFICATION_COPY.detailed).toBe('AA / NA meeting nearby · 10 min away');
+  });
+
+  it('test_notification_copy_detailed_does_not_reveal_user_preference', () => {
+    // 'detailed' shows meeting TYPE (AA/NA), not the user's specific preference tag
+    // i.e. it NEVER says "your AA meeting" or references lifestyle_preferences
+    expect(SUPPORT_NOTIFICATION_COPY.detailed).not.toMatch(/your/i);
+    expect(SUPPORT_NOTIFICATION_COPY.detailed).not.toMatch(/sober|recovery/i);
+  });
+});

--- a/supabase/migrations/001_os_state_and_presence.sql
+++ b/supabase/migrations/001_os_state_and_presence.sql
@@ -8,6 +8,7 @@
 -- ═══════════════════════════════════════════════════════════════════════════════
 
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS postgis CASCADE;  -- required for geography type in PHASE 4
 
 -- ═══════════════════════════════════════════════════════════════════════════════
 -- PHASE 1: PROFILES TABLE (auth.users.id = profiles.id)

--- a/supabase/migrations/20260501000004_v6_support_proximity.sql
+++ b/supabase/migrations/20260501000004_v6_support_proximity.sql
@@ -1,0 +1,179 @@
+-- HOTMESS v6 — Chunk 02: Support Proximity
+-- Migration: lifestyle_preferences + support_preferences columns + support_meetings table
+-- Spec: DEV_BRIEF_support-proximity.docx
+--
+-- DECOUPLING RULE: lifestyle_preferences has ZERO system effect.
+-- Only support_preferences.support_notifications_enabled activates the system.
+
+-- ─── 1. LIFESTYLE PREFERENCES — declarative only, zero system effect ────────
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS lifestyle_preferences JSONB DEFAULT NULL;
+
+COMMENT ON COLUMN profiles.lifestyle_preferences IS
+  'Declarative only. Must never trigger system behaviour. '
+  'Schema: { sober?: boolean, no_alcohol?: boolean, recovery?: boolean }. '
+  'ZERO system effect. No triggers. No logic. Private — owner only.';
+
+-- ─── 2. SUPPORT PREFERENCES — functional, controls all behaviour ─────────────
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS support_preferences JSONB
+  DEFAULT '{"support_notifications_enabled":false,"support_detail_level":"generic"}';
+
+COMMENT ON COLUMN profiles.support_preferences IS
+  'Functional. Default: disabled. Decoupled from lifestyle_preferences. '
+  'Schema: { support_notifications_enabled: boolean, support_detail_level: "generic"|"detailed" }. '
+  'Private — owner only.';
+
+-- ─── 3. RLS — block non-owner reads at DB level ──────────────────────────────
+-- Existing profiles RLS allows authenticated reads of all columns via SELECT *.
+-- We enforce owner-only at the API layer (api/profile.js stripPrivateFields).
+-- Belt-and-suspenders: update the profile SELECT policy to exclude private cols
+-- via a view rather than column-level security (CLS not supported in Supabase free tier).
+-- API-layer enforcement is the primary mechanism per spec.
+
+-- Revoke the new columns from operator_role
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'operator_role') THEN
+    -- Column-level REVOKE for the new fields
+    EXECUTE 'REVOKE ALL ON TABLE profiles FROM operator_role';
+    -- Re-grant only the aggregate-safe columns operators need
+    EXECUTE $cols$
+      GRANT SELECT (id, display_name, avatar_url, city, is_online, last_seen_at)
+      ON profiles TO operator_role
+    $cols$;
+  END IF;
+END$$;
+
+-- ─── 4. SUPPORT MEETINGS TABLE — placeholder, real data source TBD ───────────
+CREATE TABLE IF NOT EXISTS support_meetings (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  meeting_type TEXT        NOT NULL CHECK (meeting_type IN ('aa', 'na', 'other')),
+  name         TEXT,
+  lat          DECIMAL(9,6) NOT NULL,
+  lng          DECIMAL(9,6) NOT NULL,
+  day_of_week  INT         CHECK (day_of_week BETWEEN 0 AND 6),
+  start_time   TIME        NOT NULL,
+  is_active    BOOLEAN     DEFAULT true,
+  created_at   TIMESTAMPTZ DEFAULT NOW()
+);
+
+COMMENT ON TABLE support_meetings IS
+  'Placeholder. Real data source (Meeting Guide API / NA feeds) to be plugged in. '
+  'Never expose to users directly — used only for proximity calculation.';
+
+-- PostGIS location index (uses earthdistance extension)
+CREATE EXTENSION IF NOT EXISTS earthdistance CASCADE;
+CREATE EXTENSION IF NOT EXISTS cube CASCADE;
+
+CREATE INDEX IF NOT EXISTS idx_support_meetings_location
+  ON support_meetings USING BTREE (lat, lng);
+
+-- RLS on support_meetings — no direct user access, service_role only
+ALTER TABLE support_meetings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "support_meetings_service_only"
+  ON support_meetings
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Deny all other roles
+CREATE POLICY "support_meetings_deny_public"
+  ON support_meetings
+  FOR SELECT
+  TO authenticated, anon
+  USING (false);
+
+-- ─── 5. NOTIFICATION DEDUP TABLE — prevent > 1 notification per window ───────
+CREATE TABLE IF NOT EXISTS support_notification_log (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID        NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  notified_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  window_key  TEXT        NOT NULL  -- e.g. '2026-05-01-morning'
+);
+
+-- One notification per user per window
+CREATE UNIQUE INDEX IF NOT EXISTS idx_support_notif_user_window
+  ON support_notification_log (user_id, window_key);
+
+-- RLS: user can see their own log; service_role writes
+ALTER TABLE support_notification_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "support_notif_log_own_select"
+  ON support_notification_log
+  FOR SELECT
+  TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY "support_notif_log_service_insert"
+  ON support_notification_log
+  FOR INSERT
+  TO service_role
+  WITH CHECK (true);
+
+-- No UPDATE, no DELETE (append-only dedup log)
+REVOKE UPDATE, DELETE ON support_notification_log FROM anon, authenticated, service_role;
+
+-- ─── 6. OPERATOR ROLE — ensure new tables are blocked ────────────────────────
+DO $$
+DECLARE t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['support_meetings', 'support_notification_log'] LOOP
+    IF EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = t
+    ) AND EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'operator_role') THEN
+      EXECUTE format('REVOKE ALL ON TABLE %I FROM operator_role', t);
+    END IF;
+  END LOOP;
+END$$;
+
+-- ─── 7. RPC: update_support_preferences — safe partial JSONB update ──────────
+-- Called by the client to toggle enabled or change detail level.
+-- p_enabled = null means "don't change". p_detail_level = null means "don't change".
+CREATE OR REPLACE FUNCTION update_support_preferences(
+  p_user_id     UUID,
+  p_enabled     BOOLEAN DEFAULT NULL,
+  p_detail_level TEXT    DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  current_prefs JSONB;
+  new_prefs     JSONB;
+BEGIN
+  -- Owner-only: caller must match the target user
+  IF p_user_id != auth.uid() THEN
+    RAISE EXCEPTION 'Not authorised';
+  END IF;
+
+  SELECT COALESCE(support_preferences,
+    '{"support_notifications_enabled":false,"support_detail_level":"generic"}'::JSONB)
+  INTO current_prefs
+  FROM profiles
+  WHERE id = p_user_id;
+
+  new_prefs := current_prefs;
+
+  IF p_enabled IS NOT NULL THEN
+    new_prefs := jsonb_set(new_prefs, '{support_notifications_enabled}', to_jsonb(p_enabled));
+  END IF;
+
+  IF p_detail_level IS NOT NULL THEN
+    IF p_detail_level NOT IN ('generic', 'detailed') THEN
+      RAISE EXCEPTION 'Invalid detail level: %', p_detail_level;
+    END IF;
+    new_prefs := jsonb_set(new_prefs, '{support_detail_level}', to_jsonb(p_detail_level));
+  END IF;
+
+  UPDATE profiles SET support_preferences = new_prefs WHERE id = p_user_id;
+END;
+$$;
+
+-- Grant execute to authenticated users only (SECURITY DEFINER enforces owner check inside)
+GRANT EXECUTE ON FUNCTION update_support_preferences(UUID, BOOLEAN, TEXT) TO authenticated;
+REVOKE EXECUTE ON FUNCTION update_support_preferences(UUID, BOOLEAN, TEXT) FROM anon;

--- a/supabase/migrations/20260501000005_v6_support_meetings_sync.sql
+++ b/supabase/migrations/20260501000005_v6_support_meetings_sync.sql
@@ -1,0 +1,18 @@
+-- HOTMESS v6 — Chunk 02b: support_meetings sync fields
+-- Adds external_id for TSML upsert deduplication and last_synced_at tracking.
+-- Migration 000004 created the table; this extends it for the sync service.
+
+ALTER TABLE support_meetings
+  ADD COLUMN IF NOT EXISTS external_id   TEXT UNIQUE,
+  ADD COLUMN IF NOT EXISTS last_synced_at TIMESTAMPTZ DEFAULT NOW();
+
+COMMENT ON COLUMN support_meetings.external_id IS
+  'Stable ID from external source (TSML slug/id). Used for upsert deduplication in sync-meetings.js.';
+
+-- Index for sync deactivation query
+CREATE INDEX IF NOT EXISTS idx_support_meetings_external_id
+  ON support_meetings (external_id)
+  WHERE external_id IS NOT NULL;
+
+-- Keep service_role-only access (inherited from 000004 policies)
+-- No additional grants needed.

--- a/vercel.json
+++ b/vercel.json
@@ -31,6 +31,10 @@
     {
       "path": "/api/whatsapp/daily-summary",
       "schedule": "0 7 * * *"
+    },
+    {
+      "path": "/api/support/sync-meetings",
+      "schedule": "0 3 * * 0"
     }
   ],
   "routes": [


### PR DESCRIPTION
## HOTMESS v6 — Chunk 02: Support Proximity

**Branch:** `feat/v6-02-support-proximity` → `feat/v6-spec-build`
**Spec:** `DEV_BRIEF_support-proximity.docx`
**Flag:** `v6_support_proximity_ui` (default OFF)

---

### What this ships

**DB (migration `20260501000004`)**
- `profiles.lifestyle_preferences JSONB` — declarative only, zero system effect
- `profiles.support_preferences JSONB` — functional, default `{enabled:false, detail:"generic"}`
- `support_meetings` table — placeholder, real Meeting Guide API data TBD
- `support_notification_log` table — dedup log, append-only, unique index `(user_id, window_key)`
- `update_support_preferences()` RPC — SECURITY DEFINER, owner-only, safe partial JSONB update
- All tables: RLS enforced, operator_role blocked

**API (`api/profile.js`)**
- `requesterAuthId` captured from Bearer token
- `stripPrivateForNonOwner()` — deletes `lifestyle_preferences` + `support_preferences` when requester != owner
- Applied at all 3 response paths in `respondWithUser`

**Lib (`src/lib/v6/supportProximity.js`)**
- `getSupportPreferences`, `setSupportEnabled`, `setSupportDetailLevel`
- `setLifestylePreferences` — writes tag only, no system side-effects
- `checkSupportProximity` — bail if disabled, dedup window check, 2km radius, 2hr window
- `stripSupportFields` — strips both private fields from profile objects

**UI (`src/components/settings/CareSettings.jsx`)**
- Location: Settings > Care (not in chat, meet, Globe, AI surfaces)
- Toggle: "Nearby support" | Default: OFF
- Sub-option (visible when ON): General vs Specific notification detail
- HOTMESS brand: `#050507` bg, `#C8962C` gold

---

### DECOUPLING RULE
`lifestyle_preferences` has **zero system effect**.
Only `support_preferences.support_notifications_enabled = true` activates the proximity system.
These two fields are completely decoupled by design.