### PR TITLE
feat(schema): v6 pre-04 schema prereqs — trusted_contacts role + user_sessions + meet_outcomes

### DIFF
--- a/docs/v6-decisions/backup-contacts-storage.md
+++ b/docs/v6-decisions/backup-contacts-storage.md
@@ -1,0 +1,71 @@
+# Decision: backup_contacts Storage
+
+**Date:** 2026-05-01  
+**Status:** ACCEPTED  
+**Affects:** Chunk 04a (Care As Kink — Active), Chunk 04b, Chunk 05  
+
+---
+
+## Decision
+
+**Option B selected**: Store backup contacts in the existing `trusted_contacts` table using a `role` column, rather than adding a `profiles.backup_contacts` JSONB/UUID array column.
+
+---
+
+## Schema Change
+
+```sql
+ALTER TABLE trusted_contacts
+  ADD COLUMN role text NOT NULL DEFAULT 'trusted'
+  CHECK (role IN ('trusted', 'backup'));
+```
+
+Trigger `enforce_backup_contacts_limit` caps `role='backup'` rows at **2 per user**.
+
+---
+
+## Reading backup contacts in code
+
+```js
+// Care surface hook
+const { data: backups } = await supabase
+  .from('trusted_contacts')
+  .select('contact_name, contact_phone')
+  .eq('user_id', userId)
+  .eq('role', 'backup')
+  .limit(2);
+```
+
+---
+
+## Writing / updating backup contacts
+
+```js
+// Upsert a backup contact (will trigger error if > 2 exist)
+await supabase
+  .from('trusted_contacts')
+  .upsert({ user_id: userId, role: 'backup', contact_name: name, contact_phone: phone });
+```
+
+---
+
+## Spec update
+
+All references in HOTMESS-CareAsKink spec to `profiles.backup_contacts` are superseded by:
+
+> Backup contacts are stored in `trusted_contacts` where `role = 'backup'`, max 2 rows per `user_id`. See `docs/v6-decisions/backup-contacts-storage.md`.
+
+---
+
+## Rationale
+
+- `trusted_contacts` table already exists with `contact_name`, `contact_phone`, `notify_on_sos`, `notify_on_checkout`
+- Adding a redundant JSONB column on `profiles` creates two sources of truth — drift risk
+- Extending `trusted_contacts` with a `role` flag is additive and reversible
+- Care surfaces already need `contact_phone` for GET OUT notification — same row, no join
+
+---
+
+## Rejected option
+
+Option A (`profiles.backup_contacts uuid[]` or JSONB `[{name, phone}]`) was spec-word-for-word but creates redundancy with `trusted_contacts` and a 3am bug risk when sources diverge.

--- a/supabase/migrations/20260501000010_v6_pre04_schema_prereqs.sql
+++ b/supabase/migrations/20260501000010_v6_pre04_schema_prereqs.sql
@@ -1,0 +1,93 @@
+-- =============================================================================
+-- V6 PRE-04 SCHEMA PREREQS
+-- Branch: feat/v6-pre-04-schema-prereqs
+-- Decision: Option B — extend trusted_contacts with role column (backup-contacts-storage.md)
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. trusted_contacts: add role column + backup limit trigger
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE trusted_contacts
+  ADD COLUMN IF NOT EXISTS role text NOT NULL DEFAULT 'trusted'
+  CHECK (role IN ('trusted', 'backup'));
+
+COMMENT ON COLUMN trusted_contacts.role IS
+  'Contact role. trusted = standard contact, backup = Care As Kink backup (max 2 per user). See docs/v6-decisions/backup-contacts-storage.md';
+
+-- Trigger function: cap backup contacts at 2 per user
+CREATE OR REPLACE FUNCTION check_backup_contacts_limit()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.role = 'backup' THEN
+    IF (
+      SELECT COUNT(*)
+      FROM trusted_contacts
+      WHERE user_id = NEW.user_id
+        AND role = 'backup'
+        AND id != COALESCE(NEW.id, gen_random_uuid())
+    ) >= 2 THEN
+      RAISE EXCEPTION 'max_backup_contacts_exceeded';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS enforce_backup_contacts_limit ON trusted_contacts;
+CREATE TRIGGER enforce_backup_contacts_limit
+  BEFORE INSERT OR UPDATE OF role ON trusted_contacts
+  FOR EACH ROW EXECUTE FUNCTION check_backup_contacts_limit();
+
+-- ---------------------------------------------------------------------------
+-- 2. user_sessions table
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS user_sessions (
+  id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id               uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  started_at            timestamptz NOT NULL DEFAULT now(),
+  land_time             timestamptz,
+  movement_start_at     timestamptz,
+  movement_last_update  timestamptz,
+  expires_at            timestamptz,
+  meta                  jsonb NOT NULL DEFAULT '{}',
+  created_at            timestamptz NOT NULL DEFAULT now(),
+  updated_at            timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE user_sessions ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename='user_sessions' AND policyname='user_sessions_owner_only'
+  ) THEN
+    CREATE POLICY user_sessions_owner_only ON user_sessions
+      FOR ALL USING (auth.uid() = user_id);
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 3. meet_outcomes table
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS meet_outcomes (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id    uuid REFERENCES user_sessions(id) ON DELETE SET NULL,
+  user_id       uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  outcome_type  text NOT NULL CHECK (outcome_type IN ('found', 'timeout', 'cancelled', 'get_out')),
+  triggered_at  timestamptz NOT NULL DEFAULT now(),
+  meta          jsonb NOT NULL DEFAULT '{}',
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE meet_outcomes ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename='meet_outcomes' AND policyname='meet_outcomes_owner_only'
+  ) THEN
+    CREATE POLICY meet_outcomes_owner_only ON meet_outcomes
+      FOR ALL USING (auth.uid() = user_id);
+  END IF;
+END $$;


### PR DESCRIPTION
## What

Three schema items needed before Chunks 04a/04b/05 can land:

1. **`trusted_contacts.role`** — new column (`trusted` | `backup`), default `trusted`, max-2-backup trigger per user. This is the storage for Care As Kink backup contacts (Option B decision — see `docs/v6-decisions/backup-contacts-storage.md`).
2. **`user_sessions`** — table for LAND TIME (04b) and movement state (05). RLS owner-only.
3. **`meet_outcomes`** — table for FOUND/timeout/cancelled/get_out outcomes (05 + AA read). RLS owner-only.

## Status

All three are **already live on Supabase** (applied via Management API). This PR tracks them in-repo for Supabase CLI parity.

## Decision doc

`docs/v6-decisions/backup-contacts-storage.md` — records Option B selection, rationale, code patterns for Care surface hooks.

## Unblocks

- Chunk 04a (Care Active: BACKUP surface reads `trusted_contacts` where `role=backup`)
- Chunk 04b (LAND TIME writes to `user_sessions`)
- Chunk 05 (Meet writes to `meet_outcomes`, AA reads from it)

## Base

`feat/v6-spec-build`