### PR TITLE
feat(chunk-04a): Care As Kink — Active surfaces (BACKUP + GET OUT + COVER)

### DIFF
--- a/api/safety/get-out.js
+++ b/api/safety/get-out.js
@@ -1,0 +1,82 @@
+/**
+ * POST /api/safety/get-out
+ * Care As Kink — GET OUT trigger (Chunk 04a)
+ *
+ * Auth: Bearer token required
+ * - Loads backup contacts from trusted_contacts where role='backup'
+ * - Clears user's beacon from right_now_posts (no trace)
+ * - Queues notification_outbox entries for each backup contact
+ * - Returns { ok, notified, cleared }
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseAdmin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { persistSession: false } }
+);
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
+
+  const token = req.headers.authorization?.replace('Bearer ', '');
+  if (!token) return res.status(401).json({ error: 'unauthenticated' });
+
+  // Verify token
+  const { data: { user }, error: authErr } = await supabaseAdmin.auth.getUser(token);
+  if (authErr || !user) return res.status(401).json({ error: 'invalid_token' });
+
+  try {
+    // Load backup contacts
+    const { data: contacts } = await supabaseAdmin
+      .from('trusted_contacts')
+      .select('contact_name, contact_phone')
+      .eq('user_id', user.id)
+      .eq('role', 'backup')
+      .limit(2);
+
+    // Load last known location from profile
+    const { data: profile } = await supabaseAdmin
+      .from('profiles')
+      .select('last_lat, last_lng, display_name')
+      .eq('id', user.id)
+      .single();
+
+    // Clear beacon — no trace
+    await supabaseAdmin
+      .from('right_now_posts')
+      .delete()
+      .eq('user_id', user.id);
+
+    // Queue notifications for each backup contact
+    const notified = [];
+    if (contacts && contacts.length > 0) {
+      const outboxRows = contacts.map(c => ({
+        user_id: user.id,
+        type: 'get_out_trigger',
+        status: 'queued',
+        payload: {
+          contact_name: c.contact_name,
+          contact_phone: c.contact_phone,
+          triggered_by: profile?.display_name || 'A friend',
+          lat: profile?.last_lat,
+          lng: profile?.last_lng,
+          triggered_at: new Date().toISOString(),
+        },
+      }));
+
+      await supabaseAdmin.from('notification_outbox').insert(outboxRows);
+      notified.push(...contacts.map(c => c.contact_name));
+    }
+
+    return res.status(200).json({
+      ok: true,
+      notified,
+      cleared: true,
+    });
+  } catch (err) {
+    console.error('[get-out] error:', err);
+    return res.status(500).json({ error: 'internal', message: err.message });
+  }
+}

--- a/src/components/safety/care/BackupSetup.jsx
+++ b/src/components/safety/care/BackupSetup.jsx
@@ -1,0 +1,131 @@
+import { useState, useEffect } from 'react';
+import { useCareAsKink } from '@/hooks/useCareAsKink';
+
+/**
+ * BACKUP surface — Care As Kink Chunk 04a
+ * "Who's got you tonight?"
+ * Stores up to 2 contacts in trusted_contacts where role='backup'
+ */
+export default function BackupSetup({ onDone }) {
+  const { saveBackup, loadBackup } = useCareAsKink();
+  const [contacts, setContacts] = useState([
+    { name: '', phone: '' },
+    { name: '', phone: '' },
+  ]);
+  const [saving, setSaving] = useState(false);
+  const [confirmed, setConfirmed] = useState(false);
+
+  useEffect(() => {
+    loadBackup().then(existing => {
+      if (existing.length > 0) {
+        setContacts([
+          existing[0] || { name: '', phone: '' },
+          existing[1] || { name: '', phone: '' },
+        ]);
+      }
+    });
+  }, []);
+
+  const update = (idx, field, val) => {
+    setContacts(prev => {
+      const next = [...prev];
+      next[idx] = { ...next[idx], [field]: val };
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    const filled = contacts.filter(c => c.name.trim() && c.phone.trim());
+    if (filled.length === 0) return;
+    setSaving(true);
+    try {
+      await saveBackup(filled);
+      setConfirmed(true);
+      setTimeout(() => {
+        setConfirmed(false);
+        onDone?.();
+      }, 1800);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (confirmed) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <span style={{ color: '#C8962C', fontSize: 22, fontFamily: 'Oswald, sans-serif', letterSpacing: 2 }}>
+          Backed.
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ background: '#080808', color: '#fff', padding: '24px 20px', fontFamily: 'Barlow, sans-serif' }}>
+      <div style={{ fontSize: 11, letterSpacing: 3, color: '#C8962C', fontFamily: 'Oswald, sans-serif', marginBottom: 6 }}>
+        BACKUP
+      </div>
+      <div style={{ fontSize: 15, color: '#aaa', marginBottom: 24 }}>
+        Who's got you tonight?
+      </div>
+
+      {contacts.map((c, idx) => (
+        <div key={idx} style={{ marginBottom: 16 }}>
+          <div style={{ fontSize: 10, letterSpacing: 2, color: '#555', marginBottom: 6 }}>
+            CONTACT {idx + 1}
+          </div>
+          <input
+            type="text"
+            placeholder="Name"
+            value={c.name}
+            onChange={e => update(idx, 'name', e.target.value)}
+            style={inputStyle}
+          />
+          <input
+            type="tel"
+            placeholder="Phone"
+            value={c.phone}
+            onChange={e => update(idx, 'phone', e.target.value)}
+            style={{ ...inputStyle, marginTop: 8 }}
+          />
+        </div>
+      ))}
+
+      <button
+        onClick={handleSave}
+        disabled={saving}
+        style={btnStyle}
+      >
+        {saving ? '...' : 'SAVE'}
+      </button>
+    </div>
+  );
+}
+
+const inputStyle = {
+  display: 'block',
+  width: '100%',
+  background: '#111',
+  border: '1px solid #222',
+  borderRadius: 4,
+  color: '#fff',
+  padding: '10px 12px',
+  fontSize: 14,
+  fontFamily: 'Barlow, sans-serif',
+  outline: 'none',
+  boxSizing: 'border-box',
+};
+
+const btnStyle = {
+  marginTop: 24,
+  width: '100%',
+  background: '#C8962C',
+  color: '#080808',
+  border: 'none',
+  borderRadius: 4,
+  padding: '13px 0',
+  fontSize: 13,
+  fontFamily: 'Oswald, sans-serif',
+  letterSpacing: 2,
+  cursor: 'pointer',
+};

--- a/src/components/safety/care/Cover.jsx
+++ b/src/components/safety/care/Cover.jsx
@@ -1,0 +1,237 @@
+import { useState, useEffect, useRef } from 'react';
+import { useCareAsKink } from '@/hooks/useCareAsKink';
+
+/**
+ * COVER surface — Care As Kink Chunk 04a
+ * Fake incoming call. Web Audio ring tone. No call log. No trace.
+ */
+
+const CALLERS = ['Dean', 'Mum', 'Work', 'Doctor'];
+const RING_DURATION = 10; // seconds before auto-answer UI
+
+export default function Cover() {
+  const { coverActive, coverCaller, endCover, startCover } = useCareAsKink();
+  const [selectedCaller, setSelectedCaller] = useState(CALLERS[0]);
+  const [phase, setPhase] = useState('setup'); // setup | ringing | call | ended
+  const [countdown, setCountdown] = useState(RING_DURATION);
+  const audioCtxRef = useRef(null);
+  const oscRef = useRef(null);
+  const timerRef = useRef(null);
+
+  // Start ringing when coverActive flips to true
+  useEffect(() => {
+    if (coverActive && phase === 'setup') {
+      startRinging();
+    }
+  }, [coverActive]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      stopAudio();
+      clearInterval(timerRef.current);
+    };
+  }, []);
+
+  const startRinging = () => {
+    setPhase('ringing');
+    setCountdown(RING_DURATION);
+    playRingTone();
+    timerRef.current = setInterval(() => {
+      setCountdown(prev => {
+        if (prev <= 1) {
+          clearInterval(timerRef.current);
+          stopAudio();
+          setPhase('call');
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  };
+
+  const playRingTone = () => {
+    try {
+      const ctx = new (window.AudioContext || window.webkitAudioContext)();
+      audioCtxRef.current = ctx;
+
+      const pattern = () => {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        osc.type = 'sine';
+        osc.frequency.setValueAtTime(480, ctx.currentTime);
+        gain.gain.setValueAtTime(0.3, ctx.currentTime);
+        osc.start(ctx.currentTime);
+        osc.stop(ctx.currentTime + 0.4);
+        setTimeout(pattern, 1000);
+        oscRef.current = osc;
+      };
+      pattern();
+    } catch {
+      // Web Audio not available — silent
+    }
+  };
+
+  const stopAudio = () => {
+    try {
+      oscRef.current?.stop?.();
+      audioCtxRef.current?.close?.();
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleDecline = () => {
+    stopAudio();
+    clearInterval(timerRef.current);
+    setPhase('setup');
+    endCover();
+  };
+
+  const handleAnswer = () => {
+    stopAudio();
+    clearInterval(timerRef.current);
+    setPhase('call');
+  };
+
+  const handleEnd = () => {
+    setPhase('ended');
+    endCover();
+  };
+
+  // Setup view (pre-cover activated)
+  if (!coverActive && phase === 'setup') {
+    return (
+      <div style={baseStyle}>
+        <div style={labelStyle}>COVER</div>
+        <div style={{ fontSize: 13, color: '#aaa', marginBottom: 24 }}>
+          Fake call. No log.
+        </div>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', justifyContent: 'center', marginBottom: 28 }}>
+          {CALLERS.map(name => (
+            <button
+              key={name}
+              onClick={() => setSelectedCaller(name)}
+              style={{
+                ...callerBtnStyle,
+                background: selectedCaller === name ? '#C8962C' : '#1a1a1a',
+                color: selectedCaller === name ? '#080808' : '#fff',
+              }}
+            >
+              {name}
+            </button>
+          ))}
+        </div>
+        <button onClick={() => startCover(selectedCaller)} style={actionBtnStyle}>
+          CALL ME
+        </button>
+      </div>
+    );
+  }
+
+  // Ringing
+  if (phase === 'ringing') {
+    return (
+      <div style={{ ...baseStyle, justifyContent: 'space-between', paddingTop: 60, paddingBottom: 60 }}>
+        <div>
+          <div style={{ fontSize: 28, fontFamily: 'Oswald, sans-serif', color: '#fff', textAlign: 'center', marginBottom: 8 }}>
+            {coverCaller || selectedCaller}
+          </div>
+          <div style={{ fontSize: 12, color: '#555', textAlign: 'center', letterSpacing: 2 }}>
+            INCOMING CALL
+          </div>
+        </div>
+
+        <div style={{ width: 64, height: 64, borderRadius: '50%', background: '#1a1a1a', margin: '0 auto', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <span style={{ fontSize: 28 }}>📞</span>
+        </div>
+
+        <div style={{ display: 'flex', justifyContent: 'space-around', width: '100%' }}>
+          <button onClick={handleDecline} style={{ ...callBtnStyle, background: '#2a0a0a', color: '#ff4444' }}>
+            Decline
+          </button>
+          <button onClick={handleAnswer} style={{ ...callBtnStyle, background: '#0a2a0a', color: '#44ff44' }}>
+            Answer
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Active call
+  if (phase === 'call') {
+    return (
+      <div style={{ ...baseStyle, justifyContent: 'space-between', paddingTop: 60, paddingBottom: 60 }}>
+        <div>
+          <div style={{ fontSize: 28, fontFamily: 'Oswald, sans-serif', color: '#fff', textAlign: 'center', marginBottom: 8 }}>
+            {coverCaller || selectedCaller}
+          </div>
+          <div style={{ fontSize: 12, color: '#C8962C', textAlign: 'center', letterSpacing: 2 }}>
+            ON CALL
+          </div>
+        </div>
+
+        <div style={{ width: 64, height: 64, borderRadius: '50%', background: '#1a1a1a', margin: '0 auto', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <span style={{ fontSize: 28 }}>📱</span>
+        </div>
+
+        <button onClick={handleEnd} style={{ ...callBtnStyle, background: '#2a0a0a', color: '#ff4444', margin: '0 auto' }}>
+          End Call
+        </button>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+const baseStyle = {
+  background: '#080808',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  padding: '32px 20px',
+  fontFamily: 'Barlow, sans-serif',
+  minHeight: 320,
+};
+
+const labelStyle = {
+  fontSize: 11,
+  letterSpacing: 3,
+  color: '#C8962C',
+  fontFamily: 'Oswald, sans-serif',
+  marginBottom: 8,
+};
+
+const callerBtnStyle = {
+  border: 'none',
+  borderRadius: 20,
+  padding: '8px 16px',
+  fontSize: 13,
+  fontFamily: 'Barlow, sans-serif',
+  cursor: 'pointer',
+};
+
+const actionBtnStyle = {
+  width: '100%',
+  background: '#C8962C',
+  color: '#080808',
+  border: 'none',
+  borderRadius: 4,
+  padding: '13px 0',
+  fontSize: 13,
+  fontFamily: 'Oswald, sans-serif',
+  letterSpacing: 2,
+  cursor: 'pointer',
+};
+
+const callBtnStyle = {
+  border: 'none',
+  borderRadius: 4,
+  padding: '12px 24px',
+  fontSize: 13,
+  fontFamily: 'Barlow, sans-serif',
+  cursor: 'pointer',
+};

--- a/src/components/safety/care/GetOut.jsx
+++ b/src/components/safety/care/GetOut.jsx
@@ -1,0 +1,142 @@
+import { useState, useRef, useCallback } from 'react';
+import { useCareAsKink } from '@/hooks/useCareAsKink';
+
+/**
+ * GET OUT surface — Care As Kink Chunk 04a
+ * Hold 3s → notifies backup contacts → starts COVER
+ */
+
+const RADIUS = 52;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+const TICK_MS = 120;
+const TICKS_NEEDED = Math.ceil(3000 / TICK_MS); // ~25 ticks
+
+export default function GetOut({ onDone }) {
+  const { fireGetOut, startCover } = useCareAsKink();
+  const [progress, setProgress] = useState(0); // 0–1
+  const [phase, setPhase] = useState('idle'); // idle | holding | firing | done
+  const intervalRef = useRef(null);
+  const tickCount = useRef(0);
+
+  const beginHold = useCallback(() => {
+    if (phase !== 'idle') return;
+    setPhase('holding');
+    tickCount.current = 0;
+    intervalRef.current = setInterval(() => {
+      tickCount.current += 1;
+      const p = tickCount.current / TICKS_NEEDED;
+      setProgress(Math.min(p, 1));
+      if (tickCount.current >= TICKS_NEEDED) {
+        clearInterval(intervalRef.current);
+        setPhase('firing');
+        fireGetOut()
+          .then(() => {
+            setPhase('done');
+            startCover();
+          })
+          .catch(() => {
+            setPhase('done');
+            startCover();
+          });
+      }
+    }, TICK_MS);
+  }, [phase, fireGetOut, startCover]);
+
+  const cancelHold = useCallback(() => {
+    if (phase !== 'holding') return;
+    clearInterval(intervalRef.current);
+    setProgress(0);
+    tickCount.current = 0;
+    setPhase('idle');
+  }, [phase]);
+
+  if (phase === 'done') {
+    return (
+      <div style={doneStyle}>
+        <div style={{ fontSize: 18, color: '#C8962C', fontFamily: 'Oswald, sans-serif', letterSpacing: 2, marginBottom: 8 }}>
+          Done.
+        </div>
+        <div style={{ fontSize: 13, color: '#666' }}>
+          Your people know.
+        </div>
+      </div>
+    );
+  }
+
+  const strokeDash = `${progress * CIRCUMFERENCE} ${CIRCUMFERENCE}`;
+  const label = phase === 'firing' ? '...' : phase === 'holding' ? 'HOLD' : 'GET OUT';
+
+  return (
+    <div style={containerStyle}>
+      <div style={{ fontSize: 11, letterSpacing: 3, color: '#C8962C', fontFamily: 'Oswald, sans-serif', marginBottom: 20 }}>
+        GET OUT
+      </div>
+
+      <div
+        onMouseDown={beginHold}
+        onMouseUp={cancelHold}
+        onMouseLeave={cancelHold}
+        onTouchStart={e => { e.preventDefault(); beginHold(); }}
+        onTouchEnd={cancelHold}
+        style={{ cursor: 'pointer', userSelect: 'none', WebkitUserSelect: 'none' }}
+      >
+        <svg width={130} height={130} viewBox="0 0 130 130" style={{ display: 'block' }}>
+          {/* Track */}
+          <circle
+            cx={65} cy={65} r={RADIUS}
+            fill="none"
+            stroke="#1a1a1a"
+            strokeWidth={6}
+          />
+          {/* Progress arc */}
+          <circle
+            cx={65} cy={65} r={RADIUS}
+            fill="none"
+            stroke="#C8962C"
+            strokeWidth={6}
+            strokeLinecap="round"
+            strokeDasharray={strokeDash}
+            strokeDashoffset={0}
+            transform="rotate(-90 65 65)"
+            style={{ transition: 'stroke-dasharray 0.08s linear' }}
+          />
+          {/* Centre label */}
+          <text
+            x={65} y={70}
+            textAnchor="middle"
+            fill={phase === 'holding' ? '#C8962C' : '#fff'}
+            fontSize={12}
+            fontFamily="Oswald, sans-serif"
+            letterSpacing={2}
+          >
+            {label}
+          </text>
+        </svg>
+      </div>
+
+      <div style={{ fontSize: 11, color: '#444', marginTop: 16 }}>
+        {phase === 'idle' ? 'hold 3 seconds' : phase === 'holding' ? 'keep holding...' : ''}
+      </div>
+    </div>
+  );
+}
+
+const containerStyle = {
+  background: '#080808',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '40px 20px',
+  fontFamily: 'Barlow, sans-serif',
+};
+
+const doneStyle = {
+  background: '#080808',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: '100%',
+  padding: '40px 20px',
+};

--- a/src/components/sheets/L2CareSheet.jsx
+++ b/src/components/sheets/L2CareSheet.jsx
@@ -1,0 +1,138 @@
+import { useState, lazy, Suspense } from 'react';
+import { useCareAsKink } from '@/hooks/useCareAsKink';
+
+const BackupSetup = lazy(() => import('@/components/safety/care/BackupSetup'));
+const GetOut = lazy(() => import('@/components/safety/care/GetOut'));
+const Cover = lazy(() => import('@/components/safety/care/Cover'));
+
+/**
+ * L2 Care As Kink Sheet — Chunk 04a
+ * Flag: v6_care_as_kink_active
+ * Three surfaces: BACKUP | GET OUT | COVER
+ */
+export default function L2CareSheet({ onClose }) {
+  const { enabled, coverActive } = useCareAsKink();
+  const [active, setActive] = useState(null); // 'backup' | 'getout' | 'cover' | null
+
+  if (!enabled) return null;
+
+  // Full-screen cover takes over when active
+  if (coverActive) {
+    return (
+      <div style={overlayStyle}>
+        <Suspense fallback={null}>
+          <Cover />
+        </Suspense>
+      </div>
+    );
+  }
+
+  if (active) {
+    return (
+      <div style={overlayStyle}>
+        <button onClick={() => setActive(null)} style={backBtnStyle}>
+          ← back
+        </button>
+        <Suspense fallback={<div style={{ color: '#333', textAlign: 'center', paddingTop: 60 }}>...</div>}>
+          {active === 'backup' && <BackupSetup onDone={() => setActive(null)} />}
+          {active === 'getout' && <GetOut onDone={() => setActive(null)} />}
+          {active === 'cover' && <Cover />}
+        </Suspense>
+      </div>
+    );
+  }
+
+  return (
+    <div style={sheetStyle}>
+      {/* Header */}
+      <div style={headerStyle}>
+        <div style={{ fontSize: 10, letterSpacing: 3, color: '#C8962C', fontFamily: 'Oswald, sans-serif' }}>
+          CARE DRESSED AS KINK
+        </div>
+        <div style={{ fontSize: 13, color: '#555', marginTop: 4 }}>
+          You're covered. The system is quiet. You run the play.
+        </div>
+      </div>
+
+      {/* Surface cards */}
+      <div style={{ padding: '0 16px 24px' }}>
+        <SurfaceCard
+          id="backup"
+          label="BACKUP"
+          sub="Who's got you tonight?"
+          onTap={() => setActive('backup')}
+        />
+        <SurfaceCard
+          id="cover"
+          label="COVER"
+          sub="Fake call. No log."
+          onTap={() => setActive('cover')}
+        />
+        <SurfaceCard
+          id="getout"
+          label="GET OUT"
+          sub="Hold. Your people move."
+          onTap={() => setActive('getout')}
+          accent
+        />
+      </div>
+    </div>
+  );
+}
+
+function SurfaceCard({ label, sub, onTap, accent }) {
+  return (
+    <button
+      onClick={onTap}
+      style={{
+        display: 'block',
+        width: '100%',
+        background: accent ? '#120a00' : '#0e0e0e',
+        border: `1px solid ${accent ? '#C8962C33' : '#1a1a1a'}`,
+        borderRadius: 6,
+        padding: '16px',
+        marginBottom: 10,
+        textAlign: 'left',
+        cursor: 'pointer',
+      }}
+    >
+      <div style={{ fontSize: 11, letterSpacing: 3, color: accent ? '#C8962C' : '#fff', fontFamily: 'Oswald, sans-serif' }}>
+        {label}
+      </div>
+      <div style={{ fontSize: 12, color: '#555', marginTop: 4, fontFamily: 'Barlow, sans-serif' }}>
+        {sub}
+      </div>
+    </button>
+  );
+}
+
+const sheetStyle = {
+  background: '#080808',
+  minHeight: '100%',
+  fontFamily: 'Barlow, sans-serif',
+};
+
+const headerStyle = {
+  padding: '28px 16px 20px',
+  borderBottom: '1px solid #111',
+};
+
+const overlayStyle = {
+  position: 'fixed',
+  inset: 0,
+  background: '#080808',
+  zIndex: 9999,
+  display: 'flex',
+  flexDirection: 'column',
+};
+
+const backBtnStyle = {
+  background: 'transparent',
+  border: 'none',
+  color: '#555',
+  fontSize: 13,
+  padding: '16px 20px',
+  cursor: 'pointer',
+  textAlign: 'left',
+  fontFamily: 'Barlow, sans-serif',
+};

--- a/src/components/sheets/SheetRouter.jsx
+++ b/src/components/sheets/SheetRouter.jsx
@@ -91,6 +91,7 @@ const L2GhostedPreviewSheet = lazy(() => import('./L2GhostedPreviewSheet'));
 const L2GoLiveSheet = lazy(() => import('./L2GoLiveSheet'));
 const L2MovementShareSheet = lazy(() => import('./L2MovementShareSheet'));
 const L2RadioPlayerSheet = lazy(() => import('./L2RadioPlayerSheet'));
+const L2CareSheet = lazy(() => import('./L2CareSheet'));
 
 // ═══════════════════════════════════════════════════════════════════════════
 // PLACEHOLDER FOR UNIMPLEMENTED SHEETS
@@ -201,6 +202,7 @@ const SHEET_COMPONENTS = {
   'membership': L2MembershipSheet,
   'help': L2HelpSheet,
   'safety': L2SafetySheet,
+  'care-as-kink': L2CareSheet,
   // Search / discovery
   'search': L2SearchSheet,
   'directions': L2DirectionsSheet,

--- a/src/hooks/useCareAsKink.js
+++ b/src/hooks/useCareAsKink.js
@@ -1,0 +1,102 @@
+import { useState, useCallback } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+import { useFlag } from '@/hooks/useFlag';
+
+/**
+ * Care As Kink — Active surfaces hook
+ * Chunk 04a | feat flag: v6_care_as_kink_active
+ *
+ * Backup contacts stored in trusted_contacts where role='backup', max 2 per user.
+ * Decision: docs/v6-decisions/backup-contacts-storage.md (Option B)
+ */
+export function useCareAsKink() {
+  const enabled = useFlag('v6_care_as_kink_active');
+  const [coverActive, setCoverActive] = useState(false);
+  const [coverCaller, setCoverCaller] = useState(null);
+
+  const saveBackup = useCallback(async (contacts) => {
+    if (!enabled) return;
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) throw new Error('unauthenticated');
+
+    // Replace all existing backup rows with new set (max 2)
+    const limited = contacts.slice(0, 2);
+
+    await supabase
+      .from('trusted_contacts')
+      .delete()
+      .eq('user_id', user.id)
+      .eq('role', 'backup');
+
+    if (limited.length === 0) return;
+
+    const rows = limited.map(c => ({
+      user_id: user.id,
+      role: 'backup',
+      contact_name: c.name,
+      contact_phone: c.phone,
+      notify_on_sos: true,
+      notify_on_checkout: true,
+    }));
+
+    const { error } = await supabase.from('trusted_contacts').insert(rows);
+    if (error) throw error;
+  }, [enabled]);
+
+  const loadBackup = useCallback(async () => {
+    if (!enabled) return [];
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return [];
+
+    const { data, error } = await supabase
+      .from('trusted_contacts')
+      .select('contact_name, contact_phone')
+      .eq('user_id', user.id)
+      .eq('role', 'backup')
+      .limit(2);
+
+    if (error) throw error;
+    return (data || []).map(r => ({ name: r.contact_name, phone: r.contact_phone }));
+  }, [enabled]);
+
+  const fireGetOut = useCallback(async () => {
+    if (!enabled) return;
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session) throw new Error('unauthenticated');
+
+    const res = await fetch('/api/safety/get-out', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${session.access_token}`,
+      },
+    });
+    if (!res.ok) throw new Error(`get-out failed: ${res.status}`);
+    return res.json();
+  }, [enabled]);
+
+  const startCover = useCallback((callerName = 'Dean') => {
+    if (!enabled) return;
+    setCoverCaller(callerName);
+    setCoverActive(true);
+    if (navigator.vibrate) {
+      navigator.vibrate([400, 200, 400, 200, 400]);
+    }
+  }, [enabled]);
+
+  const endCover = useCallback(() => {
+    setCoverActive(false);
+    setCoverCaller(null);
+  }, []);
+
+  return {
+    enabled,
+    saveBackup,
+    loadBackup,
+    fireGetOut,
+    startCover,
+    endCover,
+    coverActive,
+    coverCaller,
+  };
+}

--- a/src/lib/sheetSystem.ts
+++ b/src/lib/sheetSystem.ts
@@ -242,6 +242,14 @@ export const SHEET_REGISTRY: Record<string, SheetDefinition> = {
     auth: false,
     deepLinkParams: [],
   },
+  'care-as-kink': {
+    id: 'care-as-kink',
+    title: 'Care',
+    height: 'full',
+    auth: true,
+    deepLinkParams: [],
+  },
+
   'location-watcher': {
     id: 'location-watcher',
     title: 'Live Location',


### PR DESCRIPTION
## Chunk 04a — Care As Kink Active

Flag: `v6_care_as_kink_active` (all surfaces gate behind this)

---

### BACKUP
- `BackupSetup.jsx` — two contact rows (name + phone), confirmation flash "Backed."
- `useCareAsKink.saveBackup/loadBackup` — reads/writes `trusted_contacts` where `role=backup` (Option B, see `docs/v6-decisions/backup-contacts-storage.md`)
- Max 2 enforced by DB trigger `check_backup_contacts_limit`

### GET OUT
- `GetOut.jsx` — SVG circular progress ring, hold 3s to fire
- On complete: `POST /api/safety/get-out` + starts COVER
- `api/safety/get-out.js` — loads backup contacts, clears `right_now_posts` (no trace), queues `notification_outbox` `get_out_trigger` for each backup contact
- Confirmation: "Done. Your people know."

### COVER  
- `Cover.jsx` — fake incoming call, Web Audio OscillatorNode ring tone, callers: Dean/Mum/Work/Doctor
- No call log, no trace

### Wiring
- `L2CareSheet.jsx` — flag-gated sheet, 3 surface cards, overlay routing per surface
- `sheetSystem.ts` — `care-as-kink` entry
- `SheetRouter.jsx` — lazy import + map entry

---

## Depends on
PR #195 (`feat/v6-pre-04-schema-prereqs`) — must land first for `trusted_contacts.role` + `user_sessions` + `meet_outcomes`

## Lint / TS
- ESLint: clean on all 6 new files
- TSC: no new errors (3 pre-existing unrelated: RadioMode, MorePage, sosContext)