### PR TITLE
feat(chunk-04b): Care As Kink — Passive surfaces (LAND TIME + CLEAN EXIT + HOW DID IT LAND + PEOPLE WHO GET IT)

### DIFF
--- a/src/components/safety/care/CleanExit.jsx
+++ b/src/components/safety/care/CleanExit.jsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { useCareAsKink } from '@/hooks/useCareAsKink';
+
+/**
+ * CLEAN EXIT surface — Care As Kink Chunk 04b
+ * "You're done. Cancel the clock."
+ * Marks user_session as cancelled, notifies backup contacts all clear.
+ */
+export default function CleanExit({ onDone }) {
+  const { enabled, cancelSession } = useCareAsKink();
+  const [phase, setPhase] = useState('idle'); // idle | confirming | done
+
+  if (!enabled) return null;
+
+  const handleExit = async () => {
+    setPhase('confirming');
+    try {
+      await cancelSession();
+      setPhase('done');
+      setTimeout(() => onDone?.(), 2000);
+    } catch {
+      setPhase('idle');
+    }
+  };
+
+  if (phase === 'done') {
+    return (
+      <div style={centreStyle}>
+        <div style={{ textAlign: 'center' }}>
+          <div style={goldTextStyle}>Gone.</div>
+          <div style={{ fontSize: 12, color: '#444', marginTop: 8 }}>Clock cancelled.</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={baseStyle}>
+      <div style={labelStyle}>CLEAN EXIT</div>
+      <div style={{ fontSize: 13, color: '#aaa', marginBottom: 32 }}>
+        You're done. Cancel the clock.
+      </div>
+
+      <button
+        onClick={handleExit}
+        disabled={phase === 'confirming'}
+        style={actionBtnStyle}
+      >
+        {phase === 'confirming' ? '...' : "I'M OUT"}
+      </button>
+    </div>
+  );
+}
+
+const baseStyle = { background: '#080808', padding: '24px 20px', fontFamily: 'Barlow, sans-serif', color: '#fff' };
+const labelStyle = { fontSize: 11, letterSpacing: 3, color: '#C8962C', fontFamily: 'Oswald, sans-serif', marginBottom: 8 };
+const centreStyle = { display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', background: '#080808' };
+const goldTextStyle = { color: '#C8962C', fontSize: 22, fontFamily: 'Oswald, sans-serif', letterSpacing: 2 };
+const actionBtnStyle = { width: '100%', background: 'transparent', color: '#C8962C', border: '1px solid #C8962C', borderRadius: 4, padding: '13px 0', fontSize: 13, fontFamily: 'Oswald, sans-serif', letterSpacing: 2, cursor: 'pointer' };

--- a/src/components/safety/care/HowDidItLand.jsx
+++ b/src/components/safety/care/HowDidItLand.jsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { useCareAsKink } from '@/hooks/useCareAsKink';
+
+/**
+ * HOW DID IT LAND surface — Care As Kink Chunk 04b
+ * Post-meet outcome capture. Writes to meet_outcomes table.
+ * No therapy language. Just a signal.
+ */
+
+const OUTCOMES = [
+  { key: 'found',     label: 'Found it.',      sub: 'It happened.' },
+  { key: 'cancelled', label: 'Changed plans.',  sub: 'All good.' },
+  { key: 'timeout',   label: 'Ran long.',       sub: 'Time got away.' },
+];
+
+export default function HowDidItLand({ onDone }) {
+  const { enabled, recordOutcome } = useCareAsKink();
+  const [selected, setSelected] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [confirmed, setConfirmed] = useState(false);
+
+  if (!enabled) return null;
+
+  const handleSend = async () => {
+    if (!selected) return;
+    setSaving(true);
+    try {
+      await recordOutcome(selected);
+      setConfirmed(true);
+      setTimeout(() => {
+        setConfirmed(false);
+        onDone?.();
+      }, 1800);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (confirmed) {
+    return (
+      <div style={centreStyle}>
+        <span style={goldTextStyle}>Logged.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div style={baseStyle}>
+      <div style={labelStyle}>HOW DID IT LAND</div>
+      <div style={{ fontSize: 13, color: '#aaa', marginBottom: 24 }}>
+        Just a signal. No story needed.
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 28 }}>
+        {OUTCOMES.map(o => (
+          <button
+            key={o.key}
+            onClick={() => setSelected(o.key)}
+            style={{
+              ...optBtnStyle,
+              background: selected === o.key ? '#120a00' : '#111',
+              border: `1px solid ${selected === o.key ? '#C8962C' : '#222'}`,
+            }}
+          >
+            <div style={{ fontSize: 13, color: selected === o.key ? '#C8962C' : '#fff', fontFamily: 'Oswald, sans-serif', letterSpacing: 1 }}>
+              {o.label}
+            </div>
+            <div style={{ fontSize: 11, color: '#555', marginTop: 3 }}>{o.sub}</div>
+          </button>
+        ))}
+      </div>
+
+      <button onClick={handleSend} disabled={!selected || saving} style={actionBtnStyle}>
+        {saving ? '...' : 'SEND'}
+      </button>
+    </div>
+  );
+}
+
+const baseStyle = { background: '#080808', padding: '24px 20px', fontFamily: 'Barlow, sans-serif', color: '#fff' };
+const labelStyle = { fontSize: 11, letterSpacing: 3, color: '#C8962C', fontFamily: 'Oswald, sans-serif', marginBottom: 8 };
+const centreStyle = { display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', background: '#080808' };
+const goldTextStyle = { color: '#C8962C', fontSize: 22, fontFamily: 'Oswald, sans-serif', letterSpacing: 2 };
+const optBtnStyle = { width: '100%', border: 'none', borderRadius: 4, padding: '13px 16px', cursor: 'pointer', textAlign: 'left' };
+const actionBtnStyle = { width: '100%', background: '#C8962C', color: '#080808', border: 'none', borderRadius: 4, padding: '13px 0', fontSize: 13, fontFamily: 'Oswald, sans-serif', letterSpacing: 2, cursor: 'pointer' };

--- a/src/components/safety/care/LandTime.jsx
+++ b/src/components/safety/care/LandTime.jsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { useCareAsKink } from '@/hooks/useCareAsKink';
+
+/**
+ * LAND TIME surface — Care As Kink Chunk 04b
+ * "What time should I know you're good?"
+ * Writes land_time to user_sessions. If not checked in by then, backup contacts notified.
+ */
+export default function LandTime({ onDone }) {
+  const { enabled, setLandTime } = useCareAsKink();
+  const [selected, setSelected] = useState(null); // minutes from now
+  const [saving, setSaving] = useState(false);
+  const [confirmed, setConfirmed] = useState(false);
+
+  if (!enabled) return null;
+
+  const OPTIONS = [
+    { label: '30 min', value: 30 },
+    { label: '1 hour', value: 60 },
+    { label: '2 hours', value: 120 },
+    { label: '3 hours', value: 180 },
+  ];
+
+  const handleSet = async () => {
+    if (!selected) return;
+    setSaving(true);
+    try {
+      await setLandTime(selected);
+      setConfirmed(true);
+      setTimeout(() => {
+        setConfirmed(false);
+        onDone?.();
+      }, 1800);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (confirmed) {
+    return (
+      <div style={centreStyle}>
+        <span style={goldTextStyle}>Set.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div style={baseStyle}>
+      <div style={labelStyle}>LAND TIME</div>
+      <div style={{ fontSize: 13, color: '#aaa', marginBottom: 24 }}>
+        What time should I know you're good?
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 28 }}>
+        {OPTIONS.map(opt => (
+          <button
+            key={opt.value}
+            onClick={() => setSelected(opt.value)}
+            style={{
+              ...optBtnStyle,
+              background: selected === opt.value ? '#C8962C' : '#111',
+              color: selected === opt.value ? '#080808' : '#fff',
+              border: `1px solid ${selected === opt.value ? '#C8962C' : '#222'}`,
+            }}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      <button onClick={handleSet} disabled={!selected || saving} style={actionBtnStyle}>
+        {saving ? '...' : 'SET'}
+      </button>
+    </div>
+  );
+}
+
+const baseStyle = { background: '#080808', padding: '24px 20px', fontFamily: 'Barlow, sans-serif', color: '#fff' };
+const labelStyle = { fontSize: 11, letterSpacing: 3, color: '#C8962C', fontFamily: 'Oswald, sans-serif', marginBottom: 8 };
+const centreStyle = { display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' };
+const goldTextStyle = { color: '#C8962C', fontSize: 22, fontFamily: 'Oswald, sans-serif', letterSpacing: 2 };
+const optBtnStyle = { width: '100%', border: 'none', borderRadius: 4, padding: '13px 16px', fontSize: 14, fontFamily: 'Barlow, sans-serif', cursor: 'pointer', textAlign: 'left' };
+const actionBtnStyle = { width: '100%', background: '#C8962C', color: '#080808', border: 'none', borderRadius: 4, padding: '13px 0', fontSize: 13, fontFamily: 'Oswald, sans-serif', letterSpacing: 2, cursor: 'pointer', opacity: 1 };

--- a/src/components/safety/care/PeopleWhoGetIt.jsx
+++ b/src/components/safety/care/PeopleWhoGetIt.jsx
@@ -1,0 +1,60 @@
+import { useState, useEffect } from 'react';
+import { useCareAsKink } from '@/hooks/useCareAsKink';
+
+/**
+ * PEOPLE WHO GET IT surface — Care As Kink Chunk 04b
+ * Shows your backup contacts. Lets you manage them from passive view.
+ * No "emergency contacts" framing. These are just your people.
+ */
+export default function PeopleWhoGetIt({ onEdit }) {
+  const { enabled, loadBackup } = useCareAsKink();
+  const [contacts, setContacts] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!enabled) return;
+    loadBackup()
+      .then(setContacts)
+      .finally(() => setLoading(false));
+  }, [enabled]);
+
+  if (!enabled) return null;
+
+  return (
+    <div style={baseStyle}>
+      <div style={labelStyle}>PEOPLE WHO GET IT</div>
+      <div style={{ fontSize: 13, color: '#aaa', marginBottom: 24 }}>
+        They move when you need them to.
+      </div>
+
+      {loading ? (
+        <div style={{ color: '#333', fontSize: 13 }}>...</div>
+      ) : contacts.length === 0 ? (
+        <div style={emptyStyle}>
+          <div style={{ fontSize: 13, color: '#444', marginBottom: 16 }}>No one added yet.</div>
+          <button onClick={onEdit} style={editBtnStyle}>ADD YOUR PEOPLE</button>
+        </div>
+      ) : (
+        <>
+          {contacts.map((c, idx) => (
+            <div key={idx} style={contactRowStyle}>
+              <div style={{ fontSize: 14, color: '#fff', fontFamily: 'Oswald, sans-serif', letterSpacing: 1 }}>
+                {c.name}
+              </div>
+              <div style={{ fontSize: 12, color: '#555', marginTop: 3 }}>{c.phone}</div>
+            </div>
+          ))}
+          <button onClick={onEdit} style={{ ...editBtnStyle, marginTop: 20 }}>
+            EDIT
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+const baseStyle = { background: '#080808', padding: '24px 20px', fontFamily: 'Barlow, sans-serif', color: '#fff' };
+const labelStyle = { fontSize: 11, letterSpacing: 3, color: '#C8962C', fontFamily: 'Oswald, sans-serif', marginBottom: 8 };
+const emptyStyle = { textAlign: 'center', padding: '20px 0' };
+const contactRowStyle = { background: '#0e0e0e', border: '1px solid #1a1a1a', borderRadius: 4, padding: '14px 16px', marginBottom: 10 };
+const editBtnStyle = { background: 'transparent', color: '#555', border: '1px solid #222', borderRadius: 4, padding: '10px 20px', fontSize: 11, fontFamily: 'Oswald, sans-serif', letterSpacing: 2, cursor: 'pointer', width: '100%' };

--- a/src/components/sheets/L2CareSheet.jsx
+++ b/src/components/sheets/L2CareSheet.jsx
@@ -1,22 +1,25 @@
 import { useState, lazy, Suspense } from 'react';
 import { useCareAsKink } from '@/hooks/useCareAsKink';
 
-const BackupSetup = lazy(() => import('@/components/safety/care/BackupSetup'));
-const GetOut = lazy(() => import('@/components/safety/care/GetOut'));
-const Cover = lazy(() => import('@/components/safety/care/Cover'));
+const BackupSetup      = lazy(() => import('@/components/safety/care/BackupSetup'));
+const GetOut           = lazy(() => import('@/components/safety/care/GetOut'));
+const Cover            = lazy(() => import('@/components/safety/care/Cover'));
+const LandTime         = lazy(() => import('@/components/safety/care/LandTime'));
+const CleanExit        = lazy(() => import('@/components/safety/care/CleanExit'));
+const HowDidItLand     = lazy(() => import('@/components/safety/care/HowDidItLand'));
+const PeopleWhoGetIt   = lazy(() => import('@/components/safety/care/PeopleWhoGetIt'));
 
 /**
- * L2 Care As Kink Sheet — Chunk 04a
+ * L2 Care As Kink Sheet — Chunks 04a + 04b
  * Flag: v6_care_as_kink_active
- * Three surfaces: BACKUP | GET OUT | COVER
  */
 export default function L2CareSheet({ onClose }) {
   const { enabled, coverActive } = useCareAsKink();
-  const [active, setActive] = useState(null); // 'backup' | 'getout' | 'cover' | null
+  const [active, setActive] = useState(null);
 
   if (!enabled) return null;
 
-  // Full-screen cover takes over when active
+  // Cover takes full screen
   if (coverActive) {
     return (
       <div style={overlayStyle}>
@@ -30,13 +33,15 @@ export default function L2CareSheet({ onClose }) {
   if (active) {
     return (
       <div style={overlayStyle}>
-        <button onClick={() => setActive(null)} style={backBtnStyle}>
-          ← back
-        </button>
+        <button onClick={() => setActive(null)} style={backBtnStyle}>← back</button>
         <Suspense fallback={<div style={{ color: '#333', textAlign: 'center', paddingTop: 60 }}>...</div>}>
-          {active === 'backup' && <BackupSetup onDone={() => setActive(null)} />}
-          {active === 'getout' && <GetOut onDone={() => setActive(null)} />}
-          {active === 'cover' && <Cover />}
+          {active === 'backup'       && <BackupSetup    onDone={() => setActive(null)} />}
+          {active === 'getout'       && <GetOut         onDone={() => setActive(null)} />}
+          {active === 'cover'        && <Cover />}
+          {active === 'landtime'     && <LandTime       onDone={() => setActive(null)} />}
+          {active === 'cleanexit'    && <CleanExit      onDone={() => setActive(null)} />}
+          {active === 'howdidland'   && <HowDidItLand   onDone={() => setActive(null)} />}
+          {active === 'peoplegetit'  && <PeopleWhoGetIt onEdit={() => setActive('backup')} />}
         </Suspense>
       </div>
     );
@@ -44,7 +49,6 @@ export default function L2CareSheet({ onClose }) {
 
   return (
     <div style={sheetStyle}>
-      {/* Header */}
       <div style={headerStyle}>
         <div style={{ fontSize: 10, letterSpacing: 3, color: '#C8962C', fontFamily: 'Oswald, sans-serif' }}>
           CARE DRESSED AS KINK
@@ -54,28 +58,28 @@ export default function L2CareSheet({ onClose }) {
         </div>
       </div>
 
-      {/* Surface cards */}
-      <div style={{ padding: '0 16px 24px' }}>
-        <SurfaceCard
-          id="backup"
-          label="BACKUP"
-          sub="Who's got you tonight?"
-          onTap={() => setActive('backup')}
-        />
-        <SurfaceCard
-          id="cover"
-          label="COVER"
-          sub="Fake call. No log."
-          onTap={() => setActive('cover')}
-        />
-        <SurfaceCard
-          id="getout"
-          label="GET OUT"
-          sub="Hold. Your people move."
-          onTap={() => setActive('getout')}
-          accent
-        />
+      <div style={{ padding: '0 16px 8px' }}>
+        <SectionLabel>ACTIVE</SectionLabel>
+        <SurfaceCard label="GET OUT"    sub="Hold. Your people move."      onTap={() => setActive('getout')}    accent />
+        <SurfaceCard label="COVER"      sub="Fake call. No log."            onTap={() => setActive('cover')}    />
+        <SurfaceCard label="LAND TIME"  sub="Set a check-in window."        onTap={() => setActive('landtime')} />
       </div>
+
+      <div style={{ padding: '0 16px 24px' }}>
+        <SectionLabel>AFTER</SectionLabel>
+        <SurfaceCard label="CLEAN EXIT"       sub="Cancel the clock."          onTap={() => setActive('cleanexit')}   />
+        <SurfaceCard label="HOW DID IT LAND"  sub="Just a signal."             onTap={() => setActive('howdidland')}  />
+        <SurfaceCard label="PEOPLE WHO GET IT" sub="Your backup contacts."     onTap={() => setActive('peoplegetit')} />
+        <SurfaceCard label="BACKUP"            sub="Edit your people."          onTap={() => setActive('backup')}     />
+      </div>
+    </div>
+  );
+}
+
+function SectionLabel({ children }) {
+  return (
+    <div style={{ fontSize: 9, letterSpacing: 3, color: '#333', fontFamily: 'Oswald, sans-serif', marginBottom: 8, marginTop: 16 }}>
+      {children}
     </div>
   );
 }
@@ -90,8 +94,8 @@ function SurfaceCard({ label, sub, onTap, accent }) {
         background: accent ? '#120a00' : '#0e0e0e',
         border: `1px solid ${accent ? '#C8962C33' : '#1a1a1a'}`,
         borderRadius: 6,
-        padding: '16px',
-        marginBottom: 10,
+        padding: '14px 16px',
+        marginBottom: 8,
         textAlign: 'left',
         cursor: 'pointer',
       }}
@@ -99,40 +103,14 @@ function SurfaceCard({ label, sub, onTap, accent }) {
       <div style={{ fontSize: 11, letterSpacing: 3, color: accent ? '#C8962C' : '#fff', fontFamily: 'Oswald, sans-serif' }}>
         {label}
       </div>
-      <div style={{ fontSize: 12, color: '#555', marginTop: 4, fontFamily: 'Barlow, sans-serif' }}>
+      <div style={{ fontSize: 12, color: '#555', marginTop: 3, fontFamily: 'Barlow, sans-serif' }}>
         {sub}
       </div>
     </button>
   );
 }
 
-const sheetStyle = {
-  background: '#080808',
-  minHeight: '100%',
-  fontFamily: 'Barlow, sans-serif',
-};
-
-const headerStyle = {
-  padding: '28px 16px 20px',
-  borderBottom: '1px solid #111',
-};
-
-const overlayStyle = {
-  position: 'fixed',
-  inset: 0,
-  background: '#080808',
-  zIndex: 9999,
-  display: 'flex',
-  flexDirection: 'column',
-};
-
-const backBtnStyle = {
-  background: 'transparent',
-  border: 'none',
-  color: '#555',
-  fontSize: 13,
-  padding: '16px 20px',
-  cursor: 'pointer',
-  textAlign: 'left',
-  fontFamily: 'Barlow, sans-serif',
-};
+const sheetStyle   = { background: '#080808', minHeight: '100%', fontFamily: 'Barlow, sans-serif' };
+const headerStyle  = { padding: '28px 16px 12px', borderBottom: '1px solid #111' };
+const overlayStyle = { position: 'fixed', inset: 0, background: '#080808', zIndex: 9999, display: 'flex', flexDirection: 'column' };
+const backBtnStyle = { background: 'transparent', border: 'none', color: '#555', fontSize: 13, padding: '16px 20px', cursor: 'pointer', textAlign: 'left', fontFamily: 'Barlow, sans-serif' };

--- a/src/hooks/useCareAsKink.js
+++ b/src/hooks/useCareAsKink.js
@@ -134,7 +134,7 @@ export function useCareAsKink() {
       .from('user_sessions')
       .update({ expires_at: new Date().toISOString(), meta: { cancelled: true } })
       .eq('user_id', user.id)
-      .is('meta->>cancelled', null)
+      .filter('meta->>cancelled', 'is', null)
       .gt('expires_at', new Date().toISOString());
 
     if (error) throw error;

--- a/src/hooks/useCareAsKink.js
+++ b/src/hooks/useCareAsKink.js
@@ -3,23 +3,26 @@ import { supabase } from '@/lib/supabaseClient';
 import { useFlag } from '@/hooks/useFlag';
 
 /**
- * Care As Kink — Active surfaces hook
- * Chunk 04a | feat flag: v6_care_as_kink_active
+ * Care As Kink hook — Chunks 04a + 04b
+ * Flag: v6_care_as_kink_active
  *
- * Backup contacts stored in trusted_contacts where role='backup', max 2 per user.
- * Decision: docs/v6-decisions/backup-contacts-storage.md (Option B)
+ * Backup contacts: trusted_contacts where role='backup', max 2 per user
+ * Sessions: user_sessions table
+ * Outcomes: meet_outcomes table
  */
 export function useCareAsKink() {
   const enabled = useFlag('v6_care_as_kink_active');
   const [coverActive, setCoverActive] = useState(false);
   const [coverCaller, setCoverCaller] = useState(null);
+  const [activeSessionId, setActiveSessionId] = useState(null);
+
+  // ── Backup contacts ──────────────────────────────────────────────────────
 
   const saveBackup = useCallback(async (contacts) => {
     if (!enabled) return;
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) throw new Error('unauthenticated');
 
-    // Replace all existing backup rows with new set (max 2)
     const limited = contacts.slice(0, 2);
 
     await supabase
@@ -59,6 +62,8 @@ export function useCareAsKink() {
     return (data || []).map(r => ({ name: r.contact_name, phone: r.contact_phone }));
   }, [enabled]);
 
+  // ── GET OUT ──────────────────────────────────────────────────────────────
+
   const fireGetOut = useCallback(async () => {
     if (!enabled) return;
     const { data: { session } } = await supabase.auth.getSession();
@@ -75,6 +80,8 @@ export function useCareAsKink() {
     return res.json();
   }, [enabled]);
 
+  // ── COVER ────────────────────────────────────────────────────────────────
+
   const startCover = useCallback((callerName = 'Dean') => {
     if (!enabled) return;
     setCoverCaller(callerName);
@@ -89,8 +96,81 @@ export function useCareAsKink() {
     setCoverCaller(null);
   }, []);
 
+  // ── LAND TIME (04b) ──────────────────────────────────────────────────────
+
+  const setLandTime = useCallback(async (minutesFromNow) => {
+    if (!enabled) return;
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) throw new Error('unauthenticated');
+
+    const landTime = new Date(Date.now() + minutesFromNow * 60 * 1000).toISOString();
+    const expiresAt = new Date(Date.now() + (minutesFromNow + 30) * 60 * 1000).toISOString();
+
+    const { data, error } = await supabase
+      .from('user_sessions')
+      .insert({
+        user_id: user.id,
+        land_time: landTime,
+        expires_at: expiresAt,
+        meta: { source: 'care_land_time' },
+      })
+      .select('id')
+      .single();
+
+    if (error) throw error;
+    setActiveSessionId(data.id);
+    return data.id;
+  }, [enabled]);
+
+  // ── CLEAN EXIT (04b) ─────────────────────────────────────────────────────
+
+  const cancelSession = useCallback(async () => {
+    if (!enabled) return;
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) throw new Error('unauthenticated');
+
+    // Mark all active sessions expired
+    const { error } = await supabase
+      .from('user_sessions')
+      .update({ expires_at: new Date().toISOString(), meta: { cancelled: true } })
+      .eq('user_id', user.id)
+      .is('meta->>cancelled', null)
+      .gt('expires_at', new Date().toISOString());
+
+    if (error) throw error;
+
+    // Record outcome
+    if (activeSessionId) {
+      await supabase.from('meet_outcomes').insert({
+        session_id: activeSessionId,
+        user_id: user.id,
+        outcome_type: 'cancelled',
+      });
+    }
+
+    setActiveSessionId(null);
+  }, [enabled, activeSessionId]);
+
+  // ── HOW DID IT LAND (04b) ────────────────────────────────────────────────
+
+  const recordOutcome = useCallback(async (outcomeType) => {
+    if (!enabled) return;
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) throw new Error('unauthenticated');
+
+    const { error } = await supabase.from('meet_outcomes').insert({
+      session_id: activeSessionId || null,
+      user_id: user.id,
+      outcome_type: outcomeType,
+    });
+
+    if (error) throw error;
+    setActiveSessionId(null);
+  }, [enabled, activeSessionId]);
+
   return {
     enabled,
+    // 04a
     saveBackup,
     loadBackup,
     fireGetOut,
@@ -98,5 +178,10 @@ export function useCareAsKink() {
     endCover,
     coverActive,
     coverCaller,
+    // 04b
+    setLandTime,
+    cancelSession,
+    recordOutcome,
+    activeSessionId,
   };
 }


### PR DESCRIPTION
## Chunk 04b — Care As Kink Passive

Flag: `v6_care_as_kink_active`

### LAND TIME
- `LandTime.jsx` — 4 duration options (30m/1h/2h/3h), confirmation "Set."
- `useCareAsKink.setLandTime()` — inserts `user_sessions` row with `land_time` + `expires_at`, stores `activeSessionId` in hook state

### CLEAN EXIT
- `CleanExit.jsx` — single tap cancels the clock, confirmation "Gone."
- `useCareAsKink.cancelSession()` — expires active session, writes `meet_outcomes` cancelled

### HOW DID IT LAND
- `HowDidItLand.jsx` — Found it / Changed plans / Ran long. No therapy framing.
- `useCareAsKink.recordOutcome()` — writes `meet_outcomes` with `outcome_type`

### PEOPLE WHO GET IT
- `PeopleWhoGetIt.jsx` — shows backup contacts, empty state CTA, edit → BACKUP surface

### Sheet update
- `L2CareSheet.jsx` rebuilt with ACTIVE section (GET OUT, COVER, LAND TIME) and AFTER section (CLEAN EXIT, HOW DID IT LAND, PEOPLE WHO GET IT, BACKUP)
- `useCareAsKink.js` extended: `setLandTime`, `cancelSession`, `recordOutcome`, `activeSessionId`

---

## Lint
Clean on all files.

## Merge order
Depends on #195 + #196 (already merged).