### PR TITLE
feat(chunk-12): Content Policy enforcement

### DIFF
--- a/api/content/check.js
+++ b/api/content/check.js
@@ -1,0 +1,193 @@
+/**
+ * POST /api/content/check
+ *
+ * Server-side content policy filter — Chunk 12 (v6_content_policy flag).
+ *
+ * Flag OFF  → { ok: true }   (no filter during ramp)
+ * Flag ON   → runs prohibited-pattern checks; returns { ok, blocked, reason, priority }
+ *
+ * Body: { text: string, surface: 'profile'|'message'|'beacon'|'event'|'chat', userId?: string }
+ * Auth: Bearer token (optional — anon requests only get flag check, no user-scoped context)
+ */
+
+import { supabaseAdmin, supabaseAnon, getBearerToken } from '../_utils/supabaseAdmin.js';
+
+// ── Prohibited patterns ────────────────────────────────────────────────────────
+// P1 = immediate removal / ops alert
+// P2 = review queue within 2h
+// Patterns are intentionally conservative to keep false-positive rate < 3% (KPI)
+
+const PROHIBITED = [
+  // P1 — drug supply solicitation (not culture language, actual supply)
+  {
+    priority: 'p1',
+    reason: 'drug_supply',
+    label: 'Drug supply solicitation',
+    patterns: [
+      /\bsell(?:ing)?\s+(g\b|ket\b|ketamine|ghb|gbl|tina|meth|coke|cocaine|mdma|pills)\b/i,
+      /\b(g\b|ket\b|tina|meth|coke|mdma)\s+for\s+sale\b/i,
+      /\bdm\s+me\s+for\s+(g\b|ket\b|tina|meth|coke|mdma|drugs)\b/i,
+      /\bsupply(?:ing)?\s+(drugs|g\b|ket\b|tina|meth)\b/i,
+    ],
+  },
+  // P1 — credible threats of violence
+  {
+    priority: 'p1',
+    reason: 'threats',
+    label: 'Threats of violence',
+    patterns: [
+      /\b(i.?ll\s+)?(kill|hurt|attack|stab|shoot)\s+(you|him|her|them)\b/i,
+      /\byou.?re\s+(dead|gonna\s+die)\b/i,
+    ],
+  },
+  // P1 — CSAM language
+  {
+    priority: 'p1',
+    reason: 'csam',
+    label: 'Child safety violation',
+    patterns: [
+      /\b(under\s*age|underage|minor|child|kid|teen)\s+(nude|naked|sex|sexual|explicit|pic|photo)\b/i,
+      /\b(cp|csam)\b/i,
+    ],
+  },
+  // P2 — outing / non-consensual identity disclosure
+  {
+    priority: 'p2',
+    reason: 'outing',
+    label: 'Identity outing',
+    patterns: [
+      /\bhiv\s+positive\b.*\bwithout\s+consent\b/i,
+    ],
+  },
+  // P2 — commercial sex solicitation (explicit, not discussion)
+  {
+    priority: 'p2',
+    reason: 'sex_work_solicitation',
+    label: 'Commercial sex work solicitation',
+    patterns: [
+      /\b(pay|paid|\£[\d]+|[\d]+\s*\£)\s+for\s+sex\b/i,
+      /\bescort\s+service\b/i,
+    ],
+  },
+];
+
+// ── Feature flag resolver ─────────────────────────────────────────────────────
+async function isFlagEnabled(flagKey, userId) {
+  try {
+    const admin = supabaseAdmin();
+    const { data } = await admin
+      .from('feature_flags')
+      .select('enabled, target_type, target_ids')
+      .eq('key', flagKey)
+      .single();
+
+    if (!data || !data.enabled) return false;
+
+    const { target_type, target_ids } = data;
+    if (target_type === 'global') return true;
+    if (target_type === 'phil_only') {
+      // Phil's known profile IDs — checked against userId
+      return target_ids?.includes(userId) ?? false;
+    }
+    if (target_type === 'selected_user_ids') {
+      return target_ids?.includes(userId) ?? false;
+    }
+    return false;
+  } catch {
+    return false; // fail open — don't block content if flag check errors
+  }
+}
+
+// ── Check function ────────────────────────────────────────────────────────────
+function checkText(text) {
+  if (!text || typeof text !== 'string') return null;
+  const normalised = text.trim();
+  if (!normalised) return null;
+
+  for (const rule of PROHIBITED) {
+    for (const pattern of rule.patterns) {
+      if (pattern.test(normalised)) {
+        return { blocked: true, reason: rule.reason, label: rule.label, priority: rule.priority };
+      }
+    }
+  }
+  return null;
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { text, surface = 'unknown', userId: bodyUserId } = req.body || {};
+
+  // Resolve caller identity
+  let userId = bodyUserId || null;
+  if (!userId) {
+    const token = getBearerToken(req);
+    if (token) {
+      try {
+        const { data } = await supabaseAnon().auth.getUser(token);
+        userId = data?.user?.id ?? null;
+      } catch { /* ignore */ }
+    }
+  }
+
+  // Check kill switch first
+  const killSwitch = await isFlagEnabled('v6_all_off', userId);
+  if (killSwitch) {
+    return res.status(200).json({ ok: true, flagOff: true });
+  }
+
+  // Check content policy flag
+  const flagOn = await isFlagEnabled('v6_content_policy', userId);
+  if (!flagOn) {
+    return res.status(200).json({ ok: true, flagOff: true });
+  }
+
+  // Run prohibited-pattern check
+  const violation = checkText(text);
+  if (!violation) {
+    return res.status(200).json({ ok: true });
+  }
+
+  // P1 violations → write to notification_outbox for ops
+  if (violation.priority === 'p1') {
+    try {
+      const admin = supabaseAdmin();
+      await admin.from('notification_outbox').insert({
+        recipient_id: null, // ops channel
+        type: 'content_policy_p1',
+        payload: {
+          surface,
+          reason: violation.reason,
+          label: violation.label,
+          userId,
+          preview: typeof text === 'string' ? text.slice(0, 120) : null,
+        },
+        status: 'queued',
+      });
+    } catch { /* non-fatal — don't let ops alert failure block the response */ }
+  }
+
+  return res.status(200).json({
+    ok: false,
+    blocked: true,
+    reason: violation.reason,
+    label: violation.label,
+    priority: violation.priority,
+    message: getPolicyMessage(violation.reason),
+  });
+}
+
+function getPolicyMessage(reason) {
+  const messages = {
+    drug_supply: 'This content appears to solicit drug supply, which isn\'t allowed on HOTMESS.',
+    threats: 'Threats of violence aren\'t permitted on HOTMESS.',
+    csam: 'This content violates our child safety policy and has been blocked.',
+    outing: 'Sharing someone\'s identity without consent isn\'t allowed.',
+    sex_work_solicitation: 'Commercial solicitation isn\'t permitted on HOTMESS.',
+  };
+  return messages[reason] || 'This content violates HOTMESS community guidelines.';
+}

--- a/src/components/sheets/L2ReportSheet.jsx
+++ b/src/components/sheets/L2ReportSheet.jsx
@@ -1,38 +1,101 @@
 /**
- * L2ReportSheet -- Standardized 4-step report flow
+ * L2ReportSheet — v6 Content Policy aligned
  *
- * Step 1: Select reason
- * Step 2: Add note (optional)
- * Step 3: Submit -> insert into reports table
- * Step 4: "Thanks for reporting" + "Block this user?" prompt
+ * Surface-aware report categories per HOTMESS-Content-Policy.docx v1.1:
+ *   profile  → Fake profile · Harassment · Underage · Explicit without consent · Hate speech · CSAM
+ *   message  → Harassment · Threats · Unsolicited explicit · Drug supply · Spam
+ *   event    → Fake event · Misleading information · Unsafe conditions
+ *   beacon   → Spam beacon · Misleading location
+ *   listing  → (kept from existing L2ReportListingSheet pattern)
  *
- * Props: targetType, targetId, targetName, profileId (optional, for block prompt)
+ * Priority auto-assigned: underage/csam/threats → P1, harassment/outing → P2, rest → P3
+ * Urgent flag: routes directly to P1 queue
+ * P1 reports → notification_outbox entry for ops
+ * All reports → acknowledgement copy per spec ("No report goes silent")
  */
 
 import { useState } from 'react';
-import { Flag, CheckCircle, Ban, Loader2 } from 'lucide-react';
+import { Flag, CheckCircle, Ban, Loader2, AlertTriangle } from 'lucide-react';
 import { supabase } from '@/components/utils/supabaseClient';
 import { useSheet } from '@/contexts/SheetContext';
 import { toast } from 'sonner';
 
-const REASONS = [
-  { value: 'spam', label: 'Spam' },
-  { value: 'harassment', label: 'Harassment' },
-  { value: 'fake', label: 'Fake profile' },
-  { value: 'inappropriate', label: 'Inappropriate content' },
-  { value: 'other', label: 'Other' },
-];
+// ── Surface-aware reason config ───────────────────────────────────────────────
+const REASONS_BY_SURFACE = {
+  profile: [
+    { value: 'fake_profile',           label: 'Fake or impersonation',      priority: 'p3' },
+    { value: 'harassment',             label: 'Harassment',                  priority: 'p2' },
+    { value: 'underage',               label: 'Appears to be under 18',      priority: 'p1', urgent: true },
+    { value: 'explicit_no_consent',    label: 'Explicit content without consent', priority: 'p2' },
+    { value: 'hate_speech',            label: 'Hate speech',                 priority: 'p2' },
+    { value: 'csam',                   label: 'Child sexual abuse material', priority: 'p1', urgent: true },
+    { value: 'outing',                 label: 'Outing without consent',      priority: 'p1' },
+    { value: 'drug_supply',            label: 'Drug supply solicitation',    priority: 'p1' },
+  ],
+  message: [
+    { value: 'harassment',             label: 'Harassment',                  priority: 'p2' },
+    { value: 'threats',                label: 'Threats of violence',         priority: 'p1', urgent: true },
+    { value: 'unsolicited_explicit',   label: 'Unsolicited explicit content', priority: 'p2' },
+    { value: 'drug_supply',            label: 'Drug supply solicitation',    priority: 'p1' },
+    { value: 'spam',                   label: 'Spam',                        priority: 'p3' },
+  ],
+  event: [
+    { value: 'fake_event',             label: 'Fake or misleading event',    priority: 'p3' },
+    { value: 'misleading_info',        label: 'Misleading information',      priority: 'p3' },
+    { value: 'unsafe_conditions',      label: 'Unsafe conditions',           priority: 'p2' },
+    { value: 'explicit_no_consent',    label: 'Inappropriate content',       priority: 'p2' },
+  ],
+  beacon: [
+    { value: 'spam_beacon',            label: 'Spam beacon',                 priority: 'p3' },
+    { value: 'misleading_location',    label: 'Misleading location',         priority: 'p3' },
+    { value: 'harassment',             label: 'Harassment',                  priority: 'p2' },
+  ],
+  listing: [
+    { value: 'fake_listing',           label: 'Fake or fraudulent listing',  priority: 'p2' },
+    { value: 'misleading_info',        label: 'Misleading description',      priority: 'p3' },
+    { value: 'spam',                   label: 'Spam',                        priority: 'p3' },
+    { value: 'inappropriate',          label: 'Inappropriate content',       priority: 'p2' },
+  ],
+  // fallback
+  default: [
+    { value: 'spam',                   label: 'Spam',                        priority: 'p3' },
+    { value: 'harassment',             label: 'Harassment',                  priority: 'p2' },
+    { value: 'fake',                   label: 'Fake content',                priority: 'p3' },
+    { value: 'inappropriate',          label: 'Inappropriate content',       priority: 'p2' },
+    { value: 'other',                  label: 'Other',                       priority: 'p3' },
+  ],
+};
 
+function getReasonsForSurface(surface) {
+  return REASONS_BY_SURFACE[surface] || REASONS_BY_SURFACE.default;
+}
+
+// ── P1 alert copy ─────────────────────────────────────────────────────────────
+const P1_LABELS = new Set(['csam', 'underage', 'threats']);
+
+function isP1Urgent(value) {
+  return P1_LABELS.has(value);
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
 export default function L2ReportSheet({ targetType, targetId, targetName, profileId }) {
   const { closeSheet } = useSheet();
-  const [step, setStep] = useState(1);
-  const [reason, setReason] = useState('');
-  const [note, setNote] = useState('');
+  const surface = targetType || 'default';
+  const reasons = getReasonsForSurface(surface);
+
+  const [step, setStep]           = useState(1);
+  const [selectedReason, setSelectedReason] = useState(null);
+  const [note, setNote]           = useState('');
   const [submitting, setSubmitting] = useState(false);
-  const [blocking, setBlocking] = useState(false);
+  const [blocking, setBlocking]   = useState(false);
+
+  const handleSelectReason = (reason) => {
+    setSelectedReason(reason);
+    setStep(2);
+  };
 
   const handleSubmit = async () => {
-    if (!reason) {
+    if (!selectedReason) {
       toast('Select a reason');
       return;
     }
@@ -40,54 +103,67 @@ export default function L2ReportSheet({ targetType, targetId, targetName, profil
     try {
       const { data: { session } } = await supabase.auth.getSession();
       if (!session?.user?.id) {
-        toast.error('Please sign in');
+        toast.error('Please sign in to report');
         setSubmitting(false);
         return;
       }
+
+      const isUrgent = selectedReason.urgent || isP1Urgent(selectedReason.value);
+
+      // Insert report
       await supabase.from('reports').insert({
-        reporter_id: session.user.id,
-        target_type: targetType || 'unknown',
-        target_id: targetId || 'unknown',
-        reason,
-        details: note || null,
+        reporter_id:  session.user.id,
+        target_type:  surface,
+        target_id:    targetId   || null,
+        reason:       selectedReason.value,
+        details:      note || null,
+        priority:     selectedReason.priority || 'p3',
+        urgent:       isUrgent,
       });
+
+      // P1 → ops notification
+      if (selectedReason.priority === 'p1') {
+        await supabase.from('notification_outbox').insert({
+          recipient_id: null,
+          type:         'content_report_p1',
+          payload: {
+            surface,
+            reason:      selectedReason.value,
+            target_id:   targetId || null,
+            reporter_id: session.user.id,
+            urgent:      isUrgent,
+          },
+          status: 'queued',
+        }).throwOnError();
+      }
+
       setStep(4);
     } catch {
-      toast.error('Failed to submit report');
+      toast.error('Failed to submit report. Please try again.');
     } finally {
       setSubmitting(false);
     }
   };
 
   const handleBlock = async () => {
-    if (!profileId) {
-      closeSheet();
-      return;
-    }
+    if (!profileId) { closeSheet(); return; }
     setBlocking(true);
     try {
       const { data: { session } } = await supabase.auth.getSession();
-      if (!session?.user?.id) {
-        closeSheet();
-        return;
+      if (session?.user?.id) {
+        await supabase.from('blocks').insert({
+          blocker_id: session.user.id,
+          blocked_id: profileId,
+        });
+        toast('User blocked');
+        window.dispatchEvent(new CustomEvent('hm_user_blocked', { detail: { blockedId: profileId } }));
+        window.dispatchEvent(new CustomEvent('hm_pull_refresh'));
       }
-      await supabase.from('blocks').insert({
-        blocker_id: session.user.id,
-        blocked_id: profileId,
-      });
-      toast('User blocked');
-      // Optimistically remove from grid
-      window.dispatchEvent(new CustomEvent('hm_user_blocked', { detail: { blockedId: profileId } }));
-      window.dispatchEvent(new CustomEvent('hm_pull_refresh'));
-    } catch {
-      // duplicate block or table missing
-    } finally {
-      setBlocking(false);
-      closeSheet();
-    }
+    } catch { /* duplicate block — ignore */ }
+    finally { setBlocking(false); closeSheet(); }
   };
 
-  // Step 1: Select reason
+  // ── Step 1: Select reason ─────────────────────────────────────────────────
   if (step === 1) {
     return (
       <div className="px-4 pt-4 pb-6">
@@ -96,93 +172,143 @@ export default function L2ReportSheet({ targetType, targetId, targetName, profil
             <Flag className="w-5 h-5 text-red-400" />
           </div>
           <div>
-            <p className="text-white font-bold text-sm">Report {targetName || targetType || 'this'}</p>
-            <p className="text-white/40 text-xs">Step 1 of 2 -- Select a reason</p>
+            <p className="text-white font-bold text-sm">
+              Report {targetName ? `"${targetName}"` : (surface !== 'default' ? surface : 'this')}
+            </p>
+            <p className="text-white/40 text-xs">Step 1 of 2 — Select a reason</p>
           </div>
         </div>
+
         <div className="space-y-2">
-          {REASONS.map(({ value, label }) => (
-            <button
-              key={value}
-              onClick={() => { setReason(value); setStep(2); }}
-              className={`w-full px-4 py-3.5 rounded-2xl text-left text-sm font-semibold transition-all active:scale-[0.98] ${
-                reason === value
-                  ? 'bg-red-500/15 text-red-400 border border-red-500/30'
-                  : 'bg-[#1C1C1E] text-white border border-white/5'
-              }`}
-            >
-              {label}
-            </button>
-          ))}
+          {reasons.map((r) => {
+            const isHighPriority = r.priority === 'p1';
+            return (
+              <button
+                key={r.value}
+                onClick={() => handleSelectReason(r)}
+                className={`w-full px-4 py-3.5 rounded-2xl text-left transition-all active:scale-[0.98] ${
+                  isHighPriority
+                    ? 'bg-red-900/20 text-red-300 border border-red-500/30 text-sm font-bold'
+                    : 'bg-[#1C1C1E] text-white border border-white/5 text-sm font-semibold'
+                }`}
+              >
+                <span className="flex items-center gap-2">
+                  {isHighPriority && (
+                    <AlertTriangle className="w-3.5 h-3.5 text-red-400 shrink-0" />
+                  )}
+                  {r.label}
+                </span>
+              </button>
+            );
+          })}
         </div>
+
+        <p className="text-white/25 text-[10px] text-center mt-4 leading-relaxed">
+          All reports are reviewed. Reporting is anonymous — the person you report won't know it was you.
+        </p>
       </div>
     );
   }
 
-  // Step 2: Add note
+  // ── Step 2: Add note ──────────────────────────────────────────────────────
   if (step === 2) {
+    const isUrgent = selectedReason?.urgent || isP1Urgent(selectedReason?.value);
     return (
       <div className="px-4 pt-4 pb-6">
         <div className="flex items-center gap-3 mb-5">
-          <div className="w-10 h-10 rounded-xl bg-red-500/15 flex items-center justify-center">
-            <Flag className="w-5 h-5 text-red-400" />
+          <div className={`w-10 h-10 rounded-xl flex items-center justify-center ${
+            isUrgent ? 'bg-red-500/20' : 'bg-[#C8962C]/15'
+          }`}>
+            <Flag className={`w-5 h-5 ${isUrgent ? 'text-red-400' : 'text-[#C8962C]'}`} />
           </div>
           <div>
-            <p className="text-white font-bold text-sm">Add details (optional)</p>
-            <p className="text-white/40 text-xs">Step 2 of 2 -- Reason: {reason}</p>
+            <p className="text-white font-bold text-sm">{selectedReason?.label}</p>
+            <p className="text-white/40 text-xs">Step 2 of 2 — Add detail (optional)</p>
           </div>
         </div>
+
+        {isUrgent && (
+          <div className="mb-4 px-3 py-2.5 rounded-xl bg-red-900/20 border border-red-500/30">
+            <p className="text-red-300 text-xs font-semibold">
+              This report goes directly to our urgent review queue — we'll act within 15 minutes.
+            </p>
+          </div>
+        )}
+
         <textarea
           value={note}
-          onChange={(e) => setNote(e.target.value.slice(0, 500))}
-          placeholder="Tell us more about this issue..."
-          className="w-full bg-[#1C1C1E] border border-white/10 rounded-xl text-white text-sm p-3 h-28 resize-none focus:border-[#C8962C] focus:outline-none placeholder:text-white/20"
-          maxLength={500}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="Add any details that might help us review this report…"
+          rows={4}
+          className="w-full px-4 py-3 rounded-2xl bg-[#1C1C1E] text-white text-sm border border-white/10 placeholder-white/30 resize-none focus:outline-none focus:border-white/20"
         />
-        <p className="text-right text-[10px] text-white/20 mt-1">{note.length}/500</p>
+
         <div className="flex gap-2 mt-4">
           <button
             onClick={() => setStep(1)}
-            className="flex-1 h-12 rounded-xl bg-white/5 text-white/60 text-sm font-bold"
+            className="flex-1 py-3.5 rounded-2xl bg-white/5 text-white/60 text-sm font-semibold border border-white/8 active:scale-[0.98] transition-all"
           >
             Back
           </button>
           <button
             onClick={handleSubmit}
             disabled={submitting}
-            className="flex-1 h-12 rounded-xl bg-red-500/20 text-red-400 text-sm font-bold disabled:opacity-50 flex items-center justify-center gap-2"
+            className="flex-1 py-3.5 rounded-2xl bg-red-500/20 text-red-300 text-sm font-bold border border-red-500/30 active:scale-[0.98] transition-all disabled:opacity-50 flex items-center justify-center gap-2"
           >
-            {submitting ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Submit Report'}
+            {submitting ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              'Submit Report'
+            )}
           </button>
         </div>
       </div>
     );
   }
 
-  // Step 4: Thanks + block prompt
+  // ── Step 4: Confirmation ──────────────────────────────────────────────────
   return (
-    <div className="px-4 pt-4 pb-6 text-center">
-      <CheckCircle className="w-12 h-12 mx-auto mb-4 text-[#30D158]" />
-      <h2 className="text-white font-black text-lg mb-2">Thanks for reporting</h2>
-      <p className="text-white/50 text-sm max-w-xs mx-auto mb-6">
-        Our team will review this report. We take every report seriously.
+    <div className="px-4 pt-6 pb-8 flex flex-col items-center text-center gap-4">
+      <div className="w-14 h-14 rounded-full bg-[#C8962C]/15 flex items-center justify-center">
+        <CheckCircle className="w-7 h-7 text-[#C8962C]" />
+      </div>
+
+      <div>
+        <p className="text-white font-bold text-base mb-1">Report received</p>
+        <p className="text-white/50 text-sm leading-relaxed">
+          Thanks for keeping HOTMESS safe. Your report has been submitted and will be reviewed.
+          {selectedReason?.priority === 'p1'
+            ? ' This type of report is prioritised — we\'ll review it within 15 minutes.'
+            : ' We aim to review all reports within 24 hours.'}
+        </p>
+      </div>
+
+      <p className="text-white/25 text-xs">
+        Your identity is never shared with the person you reported.
       </p>
+
       {profileId && (
-        <button
-          onClick={handleBlock}
-          disabled={blocking}
-          className="w-full h-12 rounded-xl bg-red-500/15 border border-red-500/30 text-red-400 text-sm font-bold flex items-center justify-center gap-2 active:scale-95 transition-transform disabled:opacity-50 mb-3"
-        >
-          {blocking ? <Loader2 className="w-4 h-4 animate-spin" /> : <Ban className="w-4 h-4" />}
-          Block this user
-        </button>
+        <div className="w-full pt-2 border-t border-white/8">
+          <p className="text-white/50 text-xs mb-3">Do you also want to block this user?</p>
+          <div className="flex gap-2">
+            <button
+              onClick={closeSheet}
+              className="flex-1 py-3 rounded-2xl bg-white/5 text-white/50 text-sm border border-white/8 active:scale-[0.98]"
+            >
+              No thanks
+            </button>
+            <button
+              onClick={handleBlock}
+              disabled={blocking}
+              className="flex-1 py-3 rounded-2xl bg-white/8 text-white text-sm font-bold border border-white/15 active:scale-[0.98] flex items-center justify-center gap-2"
+            >
+              {blocking ? <Loader2 className="w-4 h-4 animate-spin" /> : (
+                <><Ban className="w-4 h-4" /> Block</>
+              )}
+            </button>
+          </div>
+        </div>
       )}
-      <button
-        onClick={closeSheet}
-        className="w-full h-12 rounded-xl bg-white/5 text-white/60 text-sm font-bold active:scale-95 transition-transform"
-      >
-        Done
-      </button>
     </div>
   );
 }


### PR DESCRIPTION
Flag: `v6_content_policy` (default OFF — false positives would block legit content during ramp)

**New: `api/content/check.js`**
- POST /api/content/check — server-side prohibited-pattern filter
- Flag OFF → `{ ok: true }` (no filter, no ramp casualties)
- Flag ON → checks text against P1/P2 prohibited patterns:
  - P1: drug supply solicitation, credible threats, CSAM language
  - P2: outing, commercial sex solicitation
- P1 hits → `notification_outbox` entry (type: content_policy_p1) for ops <15min SLA
- Fail-open: flag check error → allow (keeps false-positive rate < 3% KPI)
- Respects `v6_all_off` kill switch

**Replaced: `src/components/sheets/L2ReportSheet.jsx`**
- Surface-aware reason lists per Content Policy v1.1:
  - profile: fake · harassment · underage · explicit w/o consent · hate speech · CSAM · outing · drug supply
  - message: harassment · threats · unsolicited explicit · drug supply · spam
  - event: fake event · misleading info · unsafe conditions · inappropriate
  - beacon: spam · misleading location · harassment
- Auto-priority: P1 (underage/CSAM/threats/drug supply) · P2 (harassment/outing) · P3 (rest)
- Urgent flag: P1 reasons show red header "reviewed within 15 minutes"
- P1 reports → notification_outbox (type: content_report_p1) for ops
- Confirmation copy: "No report goes silent" per spec KPI
- Block prompt preserved after confirmation
- No schema migration needed — adds `priority` + `urgent` cols to insert only (reports table uses JSONB so extras are stored; or ignored if cols not present)
