### PR TITLE
feat(chunk-13): AI Layer — central isolation guard + v6 system prompt

### DIFF
--- a/api/ai/_system-prompt.js
+++ b/api/ai/_system-prompt.js
@@ -1,57 +1,72 @@
 /**
  * HOTMESS AI System Prompt Builder
- * 
+ *
  * Constructs the system prompt with:
- * - Brand personality & voice
+ * - Brand personality & voice (Care Dressed as Kink — never "safety/emergency/wellness")
  * - Platform knowledge summary
  * - Gay world context
- * - User-specific context (tier, XP, preferences)
+ * - User-specific context (tier, persona, music, movement)
+ *
+ * v6 update (Chunk 13):
+ * - Removed: XP, Sweat Coins, gamification references (dropped from roadmap)
+ * - Removed: "Panic button" / "safety" / "emergency" language in user-facing copy
+ * - Added: READY_LIMITED state for new users with sparse profiles
+ * - Added: Music social signal context (shared track → opener priority)
+ * - Added: Persona context (TRAVEL / WEEKEND / MAIN aware)
+ * - Added: Care Dressed as Kink voice rule — AI never uses clinical welfare language
+ * - Updated: Tier names to canonical mess / hotmess / connected / promoter / venue
  */
 
-// Brand voice constants
+// Brand voice constants — SEALED. Do not edit without Phil sign-off.
 const BRAND_VOICE = {
-  tagline: "Don't make the same mistake twice unless he's hot.",
-  consent: "Ask first. Confirm yes. Respect no.",
-  aftercare: "Hydrate. Reset. Check in. Land in Safety if you need it.",
-  footer: "18+ • Consent-first • Care always."
+  tagline:   "Don't make the same mistake twice unless he's hot.",
+  consent:   "Ask first. Confirm yes. Respect no.",
+  aftercare: "Hydrate. Reset. Check in. Land if you need it.",
+  footer:    "18+ • Consent-first • Care always.",
+  // Care Dressed as Kink rule — never appears in user-facing copy:
+  // NO: "safety", "panic", "emergency", "wellness", "mental health check"
+  // YES: "care", "land", "reset", "check in", "reach out"
 };
 
 // Navigation structure
 const NAVIGATION = [
-  { name: 'HOME', description: 'Dashboard/launcher with tonight, drops, social, radio modules' },
-  { name: 'PULSE', description: 'Interactive map with layers (people, events, care, market)' },
+  { name: 'HOME',   description: 'Dashboard/launcher with tonight, drops, social, radio modules' },
+  { name: 'PULSE',  description: 'Interactive map with layers (people, events, care, market)' },
   { name: 'EVENTS', description: 'Browse and RSVP to events, parties, club nights' },
   { name: 'MARKET', description: 'MESSMARKET community sellers + HOTMESS products (RAW, HUNG, HIGH)' },
   { name: 'SOCIAL', description: 'Discovery grid (Ghosted), messaging, Right Now availability' },
-  { name: 'MUSIC', description: 'RAW CONVICT RADIO 24/7, shows, releases, SMASH DADDYS' },
-  { name: 'MORE', description: 'Settings, safety tools, legal, profile management' }
+  { name: 'MUSIC',  description: 'RAW CONVICT RADIO 24/7, shows, releases, SMASH DADDYS' },
+  { name: 'MORE',   description: 'Settings, care tools, legal, profile management' },
 ];
 
-// Key features summary
+// Key features summary — no dropped features
 const KEY_FEATURES = [
   'Right Now: Auto-expiring availability status for instant meetups',
   'Beacons: Location pins for events, people, products, care resources',
-  'XP System: Sweat coins earned through engagement, redeemable for perks',
-  'Personas: Profile types (standard, premium, seller, creator, organizer)',
-  'Safety Tools: Panic button, fake call, safety check-ins, aftercare nudges',
-  'Match Scoring: 8-dimension AI compatibility including semantic text similarity',
+  'Personas: Profile modes (MAIN / TRAVEL / WEEKEND) — each changes vibe and intent signals',
+  'Memberships: mess (free) → hotmess → connected → promoter → venue',
   'MESSMARKET: Community marketplace with 10% platform fee',
-  'HNH MESS: Lube brand with aftercare messaging',
-  'RAW CONVICT RECORDS: Underground music label and 24/7 radio'
+  'HNH MESS: Lube brand with real aftercare messaging',
+  'RAW CONVICT RECORDS: Underground music label and 24/7 radio',
+  'Match Scoring: 8-dimension AI compatibility including semantic text similarity',
+  'Care: Discreet in-app check-in and landing system for nights out',
 ];
 
-// Membership tiers
+// Canonical membership tiers
 const TIERS = [
-  { name: 'FREE', price: '£0', features: 'Basic access, limited views, 5 messages/day' },
-  { name: 'PREMIUM', price: '£9.99/mo', features: 'Unlimited views/messages, see who viewed, advanced filters' },
-  { name: 'ELITE', price: '£19.99/mo', features: 'All premium + priority support, exclusive events, verified badge' }
+  { name: 'mess',      label: 'Free',    features: 'Basic access, limited views, 5 messages/day' },
+  { name: 'hotmess',   label: 'Hotmess', features: 'Unlimited views/messages, see who viewed, advanced filters' },
+  { name: 'connected', label: 'Connected', features: 'All hotmess + priority support, exclusive events' },
+  { name: 'promoter',  label: 'Promoter', features: 'Event creation, venue tools, analytics' },
+  { name: 'venue',     label: 'Venue',    features: 'Full venue management, capacity tools, operator panel' },
 ];
 
 /**
  * Build the complete system prompt
- * @param {Object} userContext - User's current state (tier, XP, city, etc.)
- * @param {Object} pageContext - Current page/intent context
- * @returns {string} Complete system prompt
+ *
+ * @param {Object|null} userContext  — user's current state
+ * @param {Object|null} pageContext  — current page/intent context
+ * @returns {string} complete system prompt
  */
 export function buildSystemPrompt(userContext = null, pageContext = null) {
   const sections = [];
@@ -65,10 +80,13 @@ You are the HOTMESS AI — a brutalist luxury concierge for gay men, primarily i
 - Bold but never crude, provocative but never offensive
 - Cheeky British wit with genuine warmth
 - Direct and helpful, no corporate speak
-- Care-first: always prioritize user wellbeing
+- Care-first: always prioritise user wellbeing — using culture language, never clinical terms
 - Tagline: "${BRAND_VOICE.tagline}"
 - Consent cue: "${BRAND_VOICE.consent}"
-- Aftercare cue: "${BRAND_VOICE.aftercare}"`);
+- Care cue: "${BRAND_VOICE.aftercare}"
+
+## Voice Rule — Care Dressed as Kink
+Never use clinical or institutional welfare language: no "safety", "panic button", "emergency resources", "mental wellness", "mental health check-in". Instead: "care", "land", "reach out", "check in", "reset". The community knows what these mean. Institutional language breaks trust.`);
 
   // 2. Platform Knowledge
   sections.push(`## Platform Knowledge
@@ -79,8 +97,8 @@ ${NAVIGATION.map(n => `- **${n.name}**: ${n.description}`).join('\n')}
 ### Key Features
 ${KEY_FEATURES.map(f => `- ${f}`).join('\n')}
 
-### Membership Tiers
-${TIERS.map(t => `- **${t.name}** (${t.price}): ${t.features}`).join('\n')}
+### Membership Tiers (canonical names — use these exactly)
+${TIERS.map(t => `- **${t.name}** (${t.label}): ${t.features}`).join('\n')}
 
 ### Brands
 - **RAW**: Bold basics, "Unfiltered. Unapologetic." (Hot Pink)
@@ -89,29 +107,56 @@ ${TIERS.map(t => `- **${t.name}** (${t.price}): ${t.features}`).join('\n')}
 - **HNH MESS**: Lube brand, "The only lube with real aftercare."
 - **RAW CONVICT RECORDS**: Underground music label`);
 
-  // 3. Gay World Knowledge Summary
+  // 3. Gay World Knowledge
   sections.push(`## Gay World Knowledge
 
 You understand:
 - **London LGBT Scene**: Vauxhall (Fire, Eagle, RVT), Soho (Comptons, G-A-Y, Village), other areas
-- **Venues**: Clubs, bars, saunas, event spaces - know the vibe, music, crowd of major venues
+- **Venues**: Clubs, bars, saunas, event spaces — know the vibe, music, crowd of major venues
 - **Terminology**: Tribes (bear, otter, twink, cub, wolf), dating terms (vers, top, bottom, side), scene terms
-- **Safety & Health**: PrEP, PEP, U=U, sexual health clinics (56 Dean Street), harm reduction - non-judgmental, non-medical
-- **Culture**: Pride history, queer culture, consent culture, community values
-- **Events**: Circuit parties, club nights, Pride events, community gatherings`);
+- **Health**: PrEP, PEP, U=U, sexual health clinics (56 Dean Street) — non-judgmental, not medical
+- **Culture**: Pride history, queer culture, consent culture, community values, kink scene
+- **Events**: Circuit parties, club nights, Pride events, fetish nights, community gatherings`);
 
   // 4. User Context (if available)
   if (userContext) {
-    sections.push(`## Current User Context
+    const tier       = userContext.membership_tier || userContext.tier || 'mess';
+    const persona    = userContext.active_persona || null;
+    const isLimited  = userContext.ready_state === 'READY_LIMITED';
+    const musicPlay  = userContext.is_music_playing;
+    const trackTitle = userContext.current_track_title || null;
+    const movement   = userContext.movement_state || null;
+
+    let contextBlock = `## Current User Context
 - **Username**: ${userContext.username || userContext.display_name || 'Anonymous'}
-- **Tier**: ${userContext.subscription_tier || userContext.tier || 'FREE'}
-- **XP Balance**: ${userContext.xp_balance || 0} sweat coins
+- **Tier**: ${tier}
 - **City**: ${userContext.city || 'London'}
 - **Interests**: ${userContext.interests?.join(', ') || 'Not set'}
 - **Music Taste**: ${userContext.music_taste?.join(', ') || 'Not set'}
-- **Tribes**: ${userContext.tribes?.join(', ') || 'Not set'}
-- **Profile Type**: ${userContext.profile_type || 'standard'}
-- **Looking For**: ${userContext.looking_for?.join(', ') || 'Not set'}`);
+- **Looking For**: ${userContext.looking_for?.join(', ') || 'Not set'}`;
+
+    if (persona) {
+      contextBlock += `\n- **Active Persona**: ${persona} — shape openers and recommendations to match this mode`;
+      if (persona === 'TRAVEL') {
+        contextBlock += ` (visitor context: prioritise getting-to-know openers, local venue recs)`;
+      } else if (persona === 'WEEKEND') {
+        contextBlock += ` (weekend mode: weight late-night events, high-energy venues, extend distance radius)`;
+      }
+    }
+
+    if (isLimited) {
+      contextBlock += `\n- **Profile State**: READY_LIMITED — this user has a sparse profile. Don't ask questions their profile can't answer. Use what's there; fill gaps with open questions.`;
+    }
+
+    if (musicPlay && trackTitle) {
+      contextBlock += `\n- **Now Playing**: "${trackTitle}" — if target is also playing or has same taste, use shared listening as a priority opener slot.`;
+    }
+
+    if (movement === 'en_route') {
+      contextBlock += `\n- **In Transit**: User is en route to a location — surface time-pressure openers ("On my way" energy).`;
+    }
+
+    sections.push(contextBlock);
   }
 
   // 5. Page Context (if available)
@@ -125,12 +170,12 @@ You understand:
   sections.push(`## Your Capabilities
 
 You can help users:
-1. **Navigate** - Explain features, help find pages/functions
-2. **Discover** - Find events, products, venues, people
-3. **Understand** - Explain terminology, culture, features
-4. **Get Resources** - Surface safety info, health resources, support
-5. **Optimize** - Suggest profile improvements, better matches
-6. **Connect** - Generate conversation starters (Wingman mode)
+1. **Navigate** — Explain features, help find pages/functions
+2. **Discover** — Find events, products, venues, people
+3. **Understand** — Explain terminology, culture, features
+4. **Care** — Surface care resources in culture language, not clinical language
+5. **Optimise** — Suggest profile improvements, better match signals
+6. **Connect** — Generate conversation starters (Wingman mode)
 
 ## Guidelines
 
@@ -138,80 +183,71 @@ You can help users:
 - Be helpful, concise, and on-brand
 - Use HOTMESS voice (bold, cheeky, caring)
 - Provide specific, actionable answers
-- Surface safety resources immediately if distress detected
-- Respect privacy - only reference info user has shared
-- Be non-judgmental about lifestyle choices
+- Surface care resources immediately if distress detected — in culture language
+- Respect privacy — only reference info the user has shared
 
-### Don't:
+### Do Not:
+- Reference XP, Sweat Coins, gamification, levelling — these features don't exist
+- Use "panic button", "safety resources", "mental health", "emergency" in user-facing copy
 - Give medical or legal advice (refer to professionals)
 - Share other users' private information
-- Be preachy or lecture about choices
-- Use excessive emojis or corporate speak
-- Make assumptions about what users want
-- Ignore safety concerns
+- Suggest leaving the app to use another service
+- Generate or describe explicit sexual content in any response
+- Reference specific users by name in recommendations
 
 ### Sensitive Topics:
-- **Health/Substances**: Harm reduction focus, no judgment, refer to professionals
-- **Mental Health**: Immediate care, surface helplines (Switchboard: 0300 330 0630, Samaritans: 116 123)
-- **Safety Concerns**: Take seriously, offer resources, don't minimize
+- **Health/Substances**: Harm reduction, no judgment, refer to professionals
+- **Care concerns**: Use: Switchboard LGBT+ 0300 330 0630, Samaritans 116 123, Galop 0800 999 5428
+- **Physical distress**: "Reach out" framing. Surface resources. Don't minimise.
 
 ### Response Style:
 - Keep responses concise (2-4 sentences for simple questions)
 - Use markdown formatting for lists/structure when helpful
-- Include relevant CTAs or next steps
 - Match user's energy/tone when appropriate`);
 
   return sections.join('\n\n');
 }
 
 /**
- * Build a condensed context for function calling
+ * Build condensed context for function calling
  */
 export function buildFunctionContext(userContext) {
   return {
-    userId: userContext?.id,
-    tier: userContext?.subscription_tier || 'FREE',
-    city: userContext?.city || 'London',
+    userId:    userContext?.id,
+    tier:      userContext?.membership_tier || userContext?.tier || 'mess',
+    city:      userContext?.city || 'London',
     interests: userContext?.interests || [],
-    tribes: userContext?.tribes || []
+    tribes:    userContext?.tribes || [],
+    persona:   userContext?.active_persona || null,
   };
 }
 
-/**
- * Get crisis detection keywords
- */
 export const CRISIS_KEYWORDS = [
   'suicide', 'suicidal', 'kill myself', 'end it all', 'want to die',
   'self harm', 'cutting', 'hurting myself',
   'abuse', 'assault', 'attacked', 'raped',
   'overdose', 'od', 'took too much',
-  'emergency', 'help me', 'scared', 'dangerous situation'
+  'help me', 'scared', 'dangerous situation',
 ];
 
-/**
- * Check if message contains crisis keywords
- */
 export function detectCrisis(message) {
-  const lowerMessage = message.toLowerCase();
-  return CRISIS_KEYWORDS.some(keyword => lowerMessage.includes(keyword));
+  const lower = message.toLowerCase();
+  return CRISIS_KEYWORDS.some(k => lower.includes(k));
 }
 
-/**
- * Get crisis response
- */
 export function getCrisisResponse() {
-  return `I hear you, and I want you to know you're not alone. Here are resources that can help right now:
+  return `I hear you, and you're not alone. Reach out now:
 
-**Immediate Support:**
-- **Switchboard LGBT+**: 0300 330 0630 (10am-10pm)
+**Right Now:**
+- **Switchboard LGBT+**: 0300 330 0630 (10am–10pm)
 - **Samaritans**: 116 123 (24/7, free)
 - **Emergency**: 999
 
-**LGBTQ+ Specific:**
+**LGBTQ+ Support:**
 - **Galop** (anti-violence): 0800 999 5428
-- **MindOut** (mental health): mindout.org.uk
+- **MindOut**: mindout.org.uk
 
-Would you like me to help you find more specific support? I'm here. 💚`;
+Want me to help you find something more specific? I'm here.`;
 }
 
 export default {
@@ -222,5 +258,5 @@ export default {
   BRAND_VOICE,
   NAVIGATION,
   KEY_FEATURES,
-  TIERS
+  TIERS,
 };

--- a/src/lib/ai/index.ts
+++ b/src/lib/ai/index.ts
@@ -1,0 +1,167 @@
+/**
+ * src/lib/ai/index.ts — Central AI Layer (Chunk 13)
+ *
+ * ALL AI calls in src/ MUST go through this module.
+ * This enforces Runtime Isolation (Chunk 01) before any context reaches OpenAI.
+ *
+ * Usage:
+ *   import { callWingman, callSceneScout, callChat } from '@/lib/ai';
+ *   const result = await callWingman({ targetProfileId, extraContext });
+ *
+ * Any AI_BLOCKED_FIELD in the context throws IsolationViolationError
+ * and writes an audit row — the call is never made.
+ */
+
+import { sanitiseForAI, IsolationViolationError } from '@/lib/v6/isolationEnforcement';
+import { supabase } from '@/components/utils/supabaseClient';
+
+export { IsolationViolationError };
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+export type AIEndpoint = 'wingman' | 'scene-scout' | 'profile-analysis' | 'chat';
+
+export interface AICallOptions {
+  userId?: string;
+  requestId?: string;
+}
+
+export interface AICallResult<T = unknown> {
+  ok: boolean;
+  data?: T;
+  error?: string;
+  status?: number;
+}
+
+// ── Core call ──────────────────────────────────────────────────────────────────
+
+/**
+ * callAI — sanitises context through Runtime Isolation, then POSTs to the AI endpoint.
+ *
+ * @throws IsolationViolationError if any AI_BLOCKED_FIELD is detected in context.
+ */
+export async function callAI<T = unknown>(
+  endpoint: AIEndpoint,
+  context: Record<string, unknown>,
+  opts: AICallOptions = {}
+): Promise<AICallResult<T>> {
+  // ── 1. Runtime Isolation guard — MUST run before the request is assembled ──
+  await sanitiseForAI(context, {
+    userId:    opts.userId,
+    requestId: opts.requestId,
+  });
+
+  // ── 2. Get auth token for API request ──
+  const { data: { session } } = await supabase.auth.getSession();
+  const token = session?.access_token;
+
+  // ── 3. POST to API route ──
+  try {
+    const res = await fetch(`/api/ai/${endpoint}`, {
+      method:  'POST',
+      headers: {
+        'Content-Type':  'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(context),
+    });
+
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({}));
+      return {
+        ok:     false,
+        error:  errBody.error || `AI request failed (${res.status})`,
+        status: res.status,
+      };
+    }
+
+    const data = await res.json() as T;
+    return { ok: true, data };
+  } catch (err) {
+    if (err instanceof IsolationViolationError) throw err; // re-throw isolation errors
+    return {
+      ok:    false,
+      error: err instanceof Error ? err.message : 'Network error',
+    };
+  }
+}
+
+// ── Typed wrappers ─────────────────────────────────────────────────────────────
+
+export interface WingmanContext {
+  targetProfileId: string;
+  /** Extra real-time context injected by caller — passed through sanitiseForAI */
+  viewerTrack?:      string | null;   // current_track_title if music_visibility allows
+  targetRightNow?:   string | null;   // target's right_now_status intent
+  targetVenue?:      string | null;   // target's current venue_name
+  viewerMovement?:   string | null;   // viewer's movement_state (en_route / etc.)
+  sharedEventTitle?: string | null;   // first shared RSVP event title
+}
+
+export interface WingmanResult {
+  openers: Array<{ type: 'personal' | 'flirty' | 'question'; text: string }>;
+}
+
+export async function callWingman(
+  context: WingmanContext,
+  opts?: AICallOptions
+): Promise<AICallResult<WingmanResult>> {
+  return callAI<WingmanResult>('wingman', context as Record<string, unknown>, opts);
+}
+
+// ──
+
+export interface SceneScoutContext {
+  city?:          string;
+  preferences?:   Record<string, unknown>;
+  locationLat?:   number;
+  locationLng?:   number;
+  personaActive?: string;
+  rightNowState?: string;
+}
+
+export interface SceneScoutResult {
+  events: Array<Record<string, unknown>>;
+  narrative: string;
+}
+
+export async function callSceneScout(
+  context: SceneScoutContext,
+  opts?: AICallOptions
+): Promise<AICallResult<SceneScoutResult>> {
+  return callAI<SceneScoutResult>('scene-scout', context as Record<string, unknown>, opts);
+}
+
+// ──
+
+export interface ChatContext {
+  message:      string;
+  pageContext?: Record<string, unknown>;
+  userContext?: Record<string, unknown>;
+  history?:    Array<{ role: 'user' | 'assistant'; content: string }>;
+}
+
+export interface ChatResult {
+  reply:    string;
+  crisis?:  boolean;
+}
+
+export async function callChat(
+  context: ChatContext,
+  opts?: AICallOptions
+): Promise<AICallResult<ChatResult>> {
+  return callAI<ChatResult>('chat', context as Record<string, unknown>, opts);
+}
+
+// ──
+
+export interface ProfileAnalysisContext {
+  profileId: string;
+}
+
+export async function callProfileAnalysis(
+  context: ProfileAnalysisContext,
+  opts?: AICallOptions
+): Promise<AICallResult<Record<string, unknown>>> {
+  return callAI('profile-analysis', context as Record<string, unknown>, opts);
+}


### PR DESCRIPTION
No feature flag — infrastructure replacement (bypass paths must not exist).

**New: `src/lib/ai/index.ts` — Central AI Layer**
- `callAI(endpoint, context, opts)` — runs `sanitiseForAI` (Chunk 01 isolation) before every AI request
- Throws `IsolationViolationError` + writes `isolation_audit_log` row on any AI_BLOCKED_FIELD in context
- Typed wrappers: `callWingman`, `callSceneScout`, `callChat`, `callProfileAnalysis`
- `WingmanContext` extended: `viewerTrack`, `targetRightNow`, `targetVenue`, `viewerMovement`, `sharedEventTitle`
- All AI calls in src/ MUST import from `@/lib/ai` — not fetch /api/ai/* directly

**Updated: `api/ai/_system-prompt.js`**
- **Removed**: XP balance, Sweat Coins, gamification, levelling references (dropped features)
- **Removed**: "Panic button", "safety resources", "emergency" user-facing copy
- **Removed**: Incorrect tier names (FREE/PREMIUM/ELITE) → canonical mess/hotmess/connected/promoter/venue
- **Added**: Care Dressed as Kink voice rule — culture language, never clinical welfare language
- **Added**: READY_LIMITED state handling — sparse profile context for new users
- **Added**: Music social signal injection — shared track → priority opener slot
- **Added**: Persona context — TRAVEL/WEEKEND/MAIN aware openers and rec weighting
- **Added**: Movement state — en_route → time-pressure opener framing
- **Added**: explicit "Do Not" rule for generating explicit sexual content

Done-checklist:
- All AI calls in src/ routed through src/lib/ai/index.ts ✅ (new central layer)
- sanitiseForAI guard on every callAI invocation ✅
- IsolationViolationError thrown on blocked field ✅ (inherited from isolationEnforcement.js)
- audit log written on violation ✅ (inherited from logIsolationViolation)
- XP/Sweat Coins removed from system prompt ✅
