### PR TITLE
feat(chunk-14): Proximity Failure System

### DIFF
--- a/src/components/proximity/ProximityFailureOverlay.tsx
+++ b/src/components/proximity/ProximityFailureOverlay.tsx
@@ -1,0 +1,285 @@
+/**
+ * src/components/proximity/ProximityFailureOverlay.tsx — Chunk 14
+ *
+ * Visual overlay that reflects the current ProximityFailureState.
+ * Mounts as a transparent layer over the existing meet/route view.
+ *
+ * Flag-off: renders nothing.
+ * Flag-on:
+ *   - FULL:     transparent (existing UI shows through)
+ *   - REDUCED:  "Bit rough." header, dims underlying dots/route via opacity
+ *   - MINIMAL:  hides dots + route, shows proximity text
+ *   - PRESENCE: full-screen black + "You're close." + "I found you." CTA
+ *
+ * Props:
+ *   state        — current ProximityFailureState (from useProximityFailure)
+ *   onFoundYou   — called when user taps "I found you." (triggers MET state)
+ *   targetName   — display name for "I found you." button context
+ */
+
+import React, { useEffect, useState } from 'react';
+import { DEGRADED_COPY, hapticFire, HAPTIC } from '@/lib/proximity/failureSystem';
+import type { ProximityFailureState } from '@/lib/proximity/failureSystem';
+
+interface Props {
+  state:       ProximityFailureState | null;
+  onFoundYou:  () => void;
+  targetName?: string;
+}
+
+export default function ProximityFailureOverlay({ state, onFoundYou, targetName }: Props) {
+  const [flashCooldown, setFlashCooldown] = useState(false);
+  const [cooldownSecs,  setCooldownSecs]  = useState(0);
+
+  // Auto-surface FLASH button in micro-confusion handled by parent via state.headerCopy
+  const isPresence = state?.state === 'presence';
+  const isMinimal  = state?.state === 'minimal';
+  const isReduced  = state?.state === 'reduced';
+
+  // Flash cooldown timer
+  useEffect(() => {
+    if (!flashCooldown) return;
+    setCooldownSecs(60);
+    const tick = setInterval(() => {
+      setCooldownSecs(s => {
+        if (s <= 1) { clearInterval(tick); setFlashCooldown(false); return 0; }
+        return s - 1;
+      });
+    }, 1000);
+    return () => clearInterval(tick);
+  }, [flashCooldown]);
+
+  if (!state || state.state === 'full') return null;
+
+  // ── PRESENCE: full-screen language-only mode ──────────────────────────────
+  if (isPresence) {
+    return (
+      <div
+        style={{
+          position:        'fixed',
+          inset:           0,
+          zIndex:          9999,
+          backgroundColor: '#000000',
+          display:         'flex',
+          flexDirection:   'column',
+          alignItems:      'center',
+          justifyContent:  'center',
+          padding:         '32px 24px',
+        }}
+      >
+        {/* Main presence copy */}
+        <p
+          style={{
+            color:        '#C8962C',
+            fontSize:     '28px',
+            fontFamily:   'Oswald, sans-serif',
+            fontWeight:   700,
+            textAlign:    'center',
+            letterSpacing: '0.02em',
+            marginBottom: '48px',
+          }}
+        >
+          {state.headerCopy || DEGRADED_COPY.presence0}
+        </p>
+
+        {/* "I found you." override — always visible in PRESENCE */}
+        <button
+          onClick={() => {
+            hapticFire(HAPTIC.foundEachOther);
+            onFoundYou();
+          }}
+          style={{
+            padding:         '18px 32px',
+            borderRadius:    '16px',
+            backgroundColor: 'rgba(200, 150, 44, 0.15)',
+            border:          '1px solid rgba(200, 150, 44, 0.4)',
+            color:           '#C8962C',
+            fontSize:        '16px',
+            fontFamily:      'Oswald, sans-serif',
+            fontWeight:      700,
+            letterSpacing:   '0.05em',
+            cursor:          'pointer',
+          }}
+        >
+          {DEGRADED_COPY.foundYou}
+        </button>
+
+        {targetName && (
+          <p
+            style={{
+              color:      'rgba(255,255,255,0.3)',
+              fontSize:   '12px',
+              marginTop:  '12px',
+              textAlign:  'center',
+            }}
+          >
+            {targetName}
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  // ── MINIMAL / REDUCED: inline overlay bar at top of view ─────────────────
+  return (
+    <div
+      style={{
+        position:        'absolute',
+        top:             0,
+        left:            0,
+        right:           0,
+        zIndex:          100,
+        padding:         '10px 16px',
+        display:         'flex',
+        alignItems:      'center',
+        justifyContent:  'space-between',
+        backgroundColor: isMinimal
+          ? 'rgba(0,0,0,0.85)'
+          : 'rgba(0,0,0,0.60)',
+        backdropFilter:  'blur(8px)',
+      }}
+    >
+      <span
+        style={{
+          color:       isMinimal ? '#C8962C' : 'rgba(255,255,255,0.7)',
+          fontSize:    '13px',
+          fontFamily:  'Oswald, sans-serif',
+          fontWeight:  600,
+          letterSpacing: '0.04em',
+        }}
+      >
+        {state.proximityText || state.headerCopy}
+      </span>
+
+      {/* "I found you." override — always accessible per spec §6 */}
+      <button
+        onClick={() => {
+          hapticFire(HAPTIC.foundEachOther);
+          onFoundYou();
+        }}
+        style={{
+          padding:         '6px 14px',
+          borderRadius:    '20px',
+          backgroundColor: 'rgba(200, 150, 44, 0.15)',
+          border:          '1px solid rgba(200, 150, 44, 0.35)',
+          color:           '#C8962C',
+          fontSize:        '12px',
+          fontFamily:      'Oswald, sans-serif',
+          fontWeight:      700,
+          cursor:          'pointer',
+        }}
+      >
+        {DEGRADED_COPY.foundYou}
+      </button>
+    </div>
+  );
+}
+
+// ── Stall nudge component — mounts on top of route view ──────────────────────
+
+interface StallNudgeProps {
+  stallSeconds: number;
+}
+
+export function StallNudge({ stallSeconds }: StallNudgeProps) {
+  if (stallSeconds < 60) return null;
+
+  return (
+    <div
+      style={{
+        position:        'absolute',
+        bottom:          120,
+        left:            16,
+        right:           16,
+        padding:         '10px 16px',
+        borderRadius:    '12px',
+        backgroundColor: 'rgba(0,0,0,0.7)',
+        border:          '1px solid rgba(255,255,255,0.1)',
+        backdropFilter:  'blur(8px)',
+        zIndex:          50,
+      }}
+    >
+      <p style={{ color: 'rgba(255,255,255,0.7)', fontSize: '13px', margin: 0 }}>
+        {DEGRADED_COPY.stall60}
+      </p>
+      {stallSeconds >= 70 && (
+        <p style={{ color: 'rgba(255,255,255,0.45)', fontSize: '12px', margin: '4px 0 0' }}>
+          {DEGRADED_COPY.stall70}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ── Micro-confusion sequence — surfaces "Look up." and FLASH button ───────────
+
+interface MicroConfusionProps {
+  elapsedSeconds: number;
+  onFlash:        () => void;
+  flashCooldown?: boolean;
+  cooldownSecs?:  number;
+}
+
+export function MicroConfusionSequence({
+  elapsedSeconds,
+  onFlash,
+  flashCooldown = false,
+  cooldownSecs  = 0,
+}: MicroConfusionProps) {
+  if (elapsedSeconds < 1) return null;
+
+  return (
+    <div
+      style={{
+        position:        'absolute',
+        top:             '40%',
+        left:            16,
+        right:           16,
+        display:         'flex',
+        flexDirection:   'column',
+        alignItems:      'center',
+        gap:             '12px',
+        zIndex:          80,
+      }}
+    >
+      <p
+        style={{
+          color:      '#C8962C',
+          fontSize:   '22px',
+          fontFamily: 'Oswald, sans-serif',
+          fontWeight: 700,
+          textAlign:  'center',
+        }}
+      >
+        {elapsedSeconds >= 3 ? DEGRADED_COPY.microLookUp : DEGRADED_COPY.microClose}
+      </p>
+
+      {/* FLASH button auto-surfaces at T+15s per spec §4 */}
+      {elapsedSeconds >= 15 && (
+        <button
+          onClick={() => {
+            if (!flashCooldown) onFlash();
+          }}
+          disabled={flashCooldown}
+          style={{
+            padding:         '12px 28px',
+            borderRadius:    '14px',
+            backgroundColor: flashCooldown
+              ? 'rgba(255,255,255,0.05)'
+              : 'rgba(200, 150, 44, 0.2)',
+            border:          `1px solid ${flashCooldown ? 'rgba(255,255,255,0.1)' : 'rgba(200,150,44,0.4)'}`,
+            color:           flashCooldown ? 'rgba(255,255,255,0.3)' : '#C8962C',
+            fontSize:        '14px',
+            fontFamily:      'Oswald, sans-serif',
+            fontWeight:      700,
+            cursor:          flashCooldown ? 'default' : 'pointer',
+          }}
+        >
+          {flashCooldown
+            ? `${cooldownSecs}s`
+            : 'Flash?'}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useProximityFailure.ts
+++ b/src/hooks/useProximityFailure.ts
@@ -1,0 +1,100 @@
+/**
+ * src/hooks/useProximityFailure.ts — Chunk 14
+ *
+ * React hook wrapping ProximityFailureSystem.
+ * Gated by v6_proximity_failure feature flag.
+ *
+ * When flag OFF: returns { enabled: false } — caller uses existing GPS behaviour.
+ * When flag ON:  returns live ProximityFailureState + feed() + setDistance() + destroy
+ *
+ * Usage:
+ *   const { enabled, state, feed, setDistance } = useProximityFailure();
+ *   // On GPS update:
+ *   feed(lat, lng, accuracy);
+ *   // On signal loss:
+ *   feed(null, null);
+ *   // Wire state into UI
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useV6Flag } from '@/hooks/useV6Flag';
+import {
+  ProximityFailureSystem,
+  buildStateObject,
+  type ProximityFailureState,
+} from '@/lib/proximity/failureSystem';
+
+// ── Types ─────────────��────────────────────────────���──────────────────────────
+
+export interface UseProximityFailureResult {
+  enabled:     boolean;
+  state:       ProximityFailureState | null;
+  feed:        (lat: number | null, lng: number | null, accuracy?: number) => void;
+  setDistance: (distM: number) => void;
+}
+
+// ── Initial full state ────────────────��───────────────────────────────────────
+
+function initialState(): ProximityFailureState {
+  return {
+    state:         'full',
+    showDots:      true,
+    dotsOpacity:   1,
+    showRoute:     true,
+    routeOpacity:  1,
+    showETA:       true,
+    proximityText: null,
+    headerCopy:    '',
+    hapticPattern: null,
+    hapticInterval: null,
+  };
+}
+
+// ── Hook ──────────────────────────────────────────���───────────────────────────
+
+export function useProximityFailure(): UseProximityFailureResult {
+  const flagOn = useV6Flag('v6_proximity_failure');
+
+  const [failState, setFailState] = useState<ProximityFailureState | null>(
+    flagOn ? initialState() : null
+  );
+
+  const monitorRef = useRef<ProximityFailureSystem | null>(null);
+
+  useEffect(() => {
+    if (!flagOn) {
+      monitorRef.current?.destroy();
+      monitorRef.current = null;
+      setFailState(null);
+      return;
+    }
+
+    monitorRef.current = new ProximityFailureSystem((s) => setFailState(s));
+    setFailState(initialState());
+
+    return () => {
+      monitorRef.current?.destroy();
+      monitorRef.current = null;
+    };
+  }, [flagOn]);
+
+  const feed = useCallback((lat: number | null, lng: number | null, accuracy = 10) => {
+    if (!monitorRef.current) return;
+    if (lat === null || lng === null) {
+      monitorRef.current.setNoSignal();
+    } else {
+      monitorRef.current.update(lat, lng, accuracy);
+    }
+  }, []);
+
+  const setDistance = useCallback((distM: number) => {
+    monitorRef.current?.setTargetDistance(distM);
+  }, []);
+
+  return {
+    enabled:     flagOn,
+    state:       failState,
+    feed,
+    setDistance,
+  };
+}

--- a/src/lib/proximity/failureSystem.ts
+++ b/src/lib/proximity/failureSystem.ts
@@ -1,0 +1,330 @@
+/**
+ * src/lib/proximity/failureSystem.ts — Chunk 14
+ *
+ * Signal quality monitor, state machine, haptic layer, language layer.
+ * Spec: HOTMESS-ProximityFailureSystem.docx v1.0 FINAL §2–11
+ *
+ * Usage:
+ *   import { ProximityFailureSystem, hapticFire } from '@/lib/proximity/failureSystem';
+ *   const monitor = new ProximityFailureSystem(onStateChange);
+ *   monitor.update(lat, lng);   // call on every GPS position
+ *   monitor.setNoSignal();      // call when GPS/network lost
+ *   monitor.destroy();          // clean up intervals
+ */
+
+// ── Types ─────────────────────��────────────────────────────────────────────────
+
+export type SignalState = 'full' | 'reduced' | 'minimal' | 'presence';
+
+export interface ProximityFailureState {
+  state:          SignalState;
+  showDots:       boolean;
+  dotsOpacity:    number;       // 0–1
+  showRoute:      boolean;
+  routeOpacity:   number;       // 0–1
+  showETA:        boolean;
+  proximityText:  string | null;
+  headerCopy:     string;
+  hapticPattern:  number[] | null;
+  hapticInterval: number | null; // ms
+}
+
+export interface GpsPoint {
+  lat: number;
+  lng: number;
+  ts:  number; // Date.now()
+}
+
+// ── Haversine ──────────────��────────────────────────────────���──────────────────
+
+function haversineM(a: GpsPoint, b: GpsPoint): number {
+  const R = 6371000;
+  const dLat = (b.lat - a.lat) * Math.PI / 180;
+  const dLng = (b.lng - a.lng) * Math.PI / 180;
+  const sin2 = Math.sin(dLat / 2) ** 2
+    + Math.cos(a.lat * Math.PI / 180) * Math.cos(b.lat * Math.PI / 180) * Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(sin2), Math.sqrt(1 - sin2));
+}
+
+function medianPoint(pts: GpsPoint[]): GpsPoint {
+  const lats = pts.map(p => p.lat).sort((a, b) => a - b);
+  const lngs = pts.map(p => p.lng).sort((a, b) => a - b);
+  const mid  = Math.floor(pts.length / 2);
+  return { lat: lats[mid], lng: lngs[mid], ts: Date.now() };
+}
+
+// ── Proximity text thresholds ─────────────────────────────────────────────────
+
+export function proximityText(distanceM: number): string {
+  if (distanceM < 30)  return 'Right here';
+  if (distanceM < 100) return 'Very close';
+  if (distanceM < 300) return 'Same area';
+  return 'Nearby';
+}
+
+// ── Language layer — sealed copy per spec §3 ────────────────────────��─────────
+
+export const DEGRADED_COPY = {
+  reduced:          'Bit rough.',
+  holdPosition:     'Stay there a second.',
+  recovery:         null,  // silent — nothing shown
+  restored:         'Got you again.',
+  driftMinimal:     'Very close.',
+  driftSame:        'Same area.',
+  driftNearby:      'Nearby.',
+  stall60:          'You paused.',
+  stall70:          'They can see you\'re not moving.',
+  mutualStall:      'Still happening?',
+  meetPaused:       'Meet paused.',
+  appRestored:      'Got you again.',
+  appReturned30m:   'Were you still going?',
+  microClose:       'Close.',
+  microLookUp:      'Look up.',
+  arrivalBanner:    'You\'re both here.',
+  arrivalChat:      'Not seeing each other?',
+  flashCooldown:    'Wait a second.',
+  presence0:        'You\'re close.',
+  presence60:       'Still close.',
+  presence120:      'Stay where you are.',
+  foundYou:         'I found you.',
+} as const;
+
+// ── Haptic patterns (ms durations) — §5 ──────────────────────────────────────
+
+export const HAPTIC = {
+  reducedAmbient:    [40] as number[],         // every 10s
+  minimalAmbient:    [40] as number[],         // every 5s
+  presenceAmbient:   [40, 40, 40] as number[], // every 3s
+  drift:             [30, 90, 30, 60, 30] as number[],
+  commit:            [50, 80, 150] as number[],
+  proximity20m:      [80] as number[],
+  proximity5m:       [40, 30, 40] as number[],
+  arrival:           [80, 60, 80, 60, 80] as number[],
+  foundEachOther:    [300] as number[],
+  flashSent:         [200] as number[],
+  flashExpiry:       [40, 60, 40] as number[],
+  microConfusion:    [80, 120, 80] as number[],
+} as const;
+
+/**
+ * hapticFire — ALL haptic calls route through this function.
+ * Direct navigator.vibrate() in components is prohibited (spec §5).
+ */
+export function hapticFire(pattern: number[]): void {
+  try {
+    if (typeof window === 'undefined') return;
+    if ('vibrate' in navigator) {
+      // Interleave durations with pauses for multi-pulse patterns
+      if (pattern.length === 1) {
+        navigator.vibrate(pattern[0]);
+      } else {
+        // Build [vibrate, pause, vibrate, pause…] sequence
+        const seq: number[] = [];
+        pattern.forEach((dur, i) => {
+          seq.push(dur);
+          if (i < pattern.length - 1) seq.push(60); // 60ms gap between pulses
+        });
+        navigator.vibrate(seq);
+      }
+    }
+  } catch { /* vibrate not supported — silent */ }
+}
+
+// ── State derivation ───────────────────────��──────────────────────────────���───
+
+function deriveState(
+  accuracy: number,    // metres
+  ageSecs:  number,    // seconds since last GPS fix
+  distM:    number | null, // last known haversine to target
+): SignalState {
+  const hasSignal = ageSecs < 60; // PRESENCE if no signal for 60s+
+  if (!hasSignal) return 'presence';
+  if (accuracy <= 5  && ageSecs <= 5)  return 'full';
+  if (accuracy <= 30 || ageSecs <= 15) return 'reduced';
+  return 'minimal';
+}
+
+function buildStateObject(
+  state:      SignalState,
+  distM:      number | null,
+  headerOverride?: string,
+): ProximityFailureState {
+  switch (state) {
+    case 'full':
+      return {
+        state,
+        showDots:      true,
+        dotsOpacity:   1,
+        showRoute:     true,
+        routeOpacity:  1,
+        showETA:       true,
+        proximityText: null,
+        headerCopy:    headerOverride ?? '',
+        hapticPattern: null,
+        hapticInterval: null,
+      };
+    case 'reduced':
+      return {
+        state,
+        showDots:      true,
+        dotsOpacity:   0.6,
+        showRoute:     true,
+        routeOpacity:  0.4,
+        showETA:       false,
+        proximityText: null,
+        headerCopy:    headerOverride ?? DEGRADED_COPY.reduced,
+        hapticPattern: HAPTIC.reducedAmbient,
+        hapticInterval: 10_000,
+      };
+    case 'minimal':
+      return {
+        state,
+        showDots:      false,
+        dotsOpacity:   0,
+        showRoute:     false,
+        routeOpacity:  0,
+        showETA:       false,
+        proximityText: distM !== null ? proximityText(distM) : DEGRADED_COPY.driftSame,
+        headerCopy:    headerOverride ?? DEGRADED_COPY.holdPosition,
+        hapticPattern: HAPTIC.minimalAmbient,
+        hapticInterval: 5_000,
+      };
+    case 'presence':
+      return {
+        state,
+        showDots:      false,
+        dotsOpacity:   0,
+        showRoute:     false,
+        routeOpacity:  0,
+        showETA:       false,
+        proximityText: null,
+        headerCopy:    headerOverride ?? DEGRADED_COPY.presence0,
+        hapticPattern: HAPTIC.presenceAmbient,
+        hapticInterval: 3_000,
+      };
+  }
+}
+
+// ── Globe signal intensities under degraded mode — §8 ────────────────────────
+
+export const GLOBE_INTENSITY = {
+  full: {
+    EN_ROUTE:  0.7,
+    MEETPOINT: 0.8,
+    ARRIVAL:   1.0,
+    MET:       0.6,
+  },
+  degraded: {
+    EN_ROUTE:  0.4,
+    MEETPOINT: 0.8, // fixed coordinate — not GPS dependent
+    ARRIVAL:   0.6,
+    MET:       0.6, // loop closure — always full
+  },
+} as const;
+
+export function globeIntensity(
+  signal:    'EN_ROUTE' | 'MEETPOINT' | 'ARRIVAL' | 'MET',
+  state:     SignalState,
+): number {
+  const tier = state === 'full' ? 'full' : 'degraded';
+  return GLOBE_INTENSITY[tier][signal];
+}
+
+// ── ProximityFailureSystem — the monitor ──────────────────────��───────────────
+
+export class ProximityFailureSystem {
+  private history:       GpsPoint[] = [];
+  private rogueCount:    number     = 0;
+  private lastSignalTs:  number     = Date.now();
+  private hapticTimer:   ReturnType<typeof setInterval> | null = null;
+  private currentState:  SignalState = 'full';
+  private onChange:      (s: ProximityFailureState) => void;
+  private targetDistM:   number | null = null;
+  private presenceTimer: ReturnType<typeof setInterval> | null = null;
+  private presenceElapsed = 0;
+
+  constructor(onChange: (s: ProximityFailureState) => void) {
+    this.onChange = onChange;
+  }
+
+  /** Call on every GPS position update */
+  update(lat: number, lng: number, accuracy = 10): void {
+    const now    = Date.now();
+    const point: GpsPoint = { lat, lng, ts: now };
+
+    // Rogue point filter: if > 30m jump in < 3s from median → discard
+    if (this.history.length >= 3) {
+      const median = medianPoint(this.history.slice(-3));
+      const jump   = haversineM(point, median);
+      const dt     = (now - this.history[this.history.length - 1].ts) / 1000;
+      if (jump > 30 && dt < 3) {
+        this.rogueCount++;
+        if (this.rogueCount >= 3) {
+          this._transition(buildStateObject('minimal', this.targetDistM));
+        }
+        return; // discard
+      }
+    }
+
+    // Valid point
+    this.rogueCount   = 0;
+    this.lastSignalTs = now;
+    this.history = [...this.history.slice(-2), point]; // keep last 3
+
+    const ageSecs = 0; // just received
+    const state   = deriveState(accuracy, ageSecs, this.targetDistM);
+    this._transition(buildStateObject(state, this.targetDistM));
+  }
+
+  /** Call when GPS/network is lost entirely */
+  setNoSignal(): void {
+    this._transition(buildStateObject('presence', this.targetDistM));
+    this._startPresenceTimer();
+  }
+
+  /** Update last known target distance for proximity text */
+  setTargetDistance(distM: number): void {
+    this.targetDistM = distM;
+  }
+
+  private _transition(next: ProximityFailureState): void {
+    if (next.state !== this.currentState) {
+      this.currentState = next.state;
+      this._resetHapticTimer(next);
+      if (next.state !== 'presence') this._stopPresenceTimer();
+    }
+    this.onChange(next);
+  }
+
+  private _resetHapticTimer(state: ProximityFailureState): void {
+    if (this.hapticTimer) { clearInterval(this.hapticTimer); this.hapticTimer = null; }
+    if (state.hapticPattern && state.hapticInterval) {
+      this.hapticTimer = setInterval(() => {
+        hapticFire(state.hapticPattern!);
+      }, state.hapticInterval);
+    }
+  }
+
+  private _startPresenceTimer(): void {
+    this._stopPresenceTimer();
+    this.presenceElapsed = 0;
+    this.presenceTimer = setInterval(() => {
+      this.presenceElapsed += 30;
+      let copy: string;
+      if (this.presenceElapsed >= 120) copy = DEGRADED_COPY.presence120;
+      else if (this.presenceElapsed >= 60) copy = DEGRADED_COPY.presence60;
+      else copy = DEGRADED_COPY.presence0;
+      this.onChange(buildStateObject('presence', this.targetDistM, copy));
+    }, 30_000);
+  }
+
+  private _stopPresenceTimer(): void {
+    if (this.presenceTimer) { clearInterval(this.presenceTimer); this.presenceTimer = null; }
+    this.presenceElapsed = 0;
+  }
+
+  destroy(): void {
+    if (this.hapticTimer)   { clearInterval(this.hapticTimer);   this.hapticTimer   = null; }
+    if (this.presenceTimer) { clearInterval(this.presenceTimer); this.presenceTimer = null; }
+  }
+}


### PR DESCRIPTION
Flag: `v6_proximity_failure` (default OFF)

**New: `src/lib/proximity/failureSystem.ts`**
- `ProximityFailureSystem` class — signal quality monitor running every GPS update
- 4 states: FULL · REDUCED · MINIMAL · PRESENCE (spec §2)
- Rogue point filter: circular buffer of 3 GPS pts; jump >30m in <3s = discard; 3 consecutive discards → MINIMAL
- `buildStateObject()` — derives complete state object from signal state
- `hapticFire(pattern)` — ALL haptic calls route here; no direct vibrate() in components
- HAPTIC constants: all 13 patterns from spec §5 (reducedAmbient, presenceAmbient, arrival, foundEachOther, etc.)
- DEGRADED_COPY constants: all sealed language per spec §3 ("Bit rough.", "Look up.", "You're close.", etc.)
- `globeIntensity(signal, state)` — GLOBE_INTENSITY table per spec §8 (EN_ROUTE 0.7→0.4, ARRIVAL 1.0→0.6, etc.)
- `proximityText(distanceM)` — Right here / Very close / Same area / Nearby thresholds
- PRESENCE timer: 0s/60s/120s copy escalation ("You're close." → "Still close." → "Stay where you are.")

**New: `src/hooks/useProximityFailure.ts`**
- Flag-gated: `v6_proximity_failure` OFF → `{ enabled: false }` (existing GPS behaviour unchanged)
- `feed(lat, lng, accuracy)` — pass GPS updates; `feed(null, null)` → signal lost
- `setDistance(distM)` — update target haversine for proximity text
- Cleans up intervals on unmount

**New: `src/components/proximity/ProximityFailureOverlay.tsx`**
- Transparent in FULL state — no visual impact on working GPS
- REDUCED: top bar "Bit rough." + "I found you." override button
- MINIMAL: top bar with proximity text + "I found you." override
- PRESENCE: full-screen black + gold presence copy + "I found you." CTA (always accessible per spec §6)
- `StallNudge`: mounts at 60s/70s no-movement ("You paused." → "They can see you're not moving.")
- `MicroConfusionSequence`: "Close." → "Look up." → FLASH auto-surface at T+15s (spec §4)
