### PR TITLE
feat(chunk-15): Sound of the Night

### DIFF
--- a/src/components/home/PulseModeWidget.tsx
+++ b/src/components/home/PulseModeWidget.tsx
@@ -1,0 +1,289 @@
+/**
+ * src/components/home/PulseModeWidget.tsx — Chunk 15
+ *
+ * City dashboard — visual output of all five Sound of the Night systems.
+ * Flag-gated: v6_sound_of_the_night
+ *
+ * Reads (no writes):
+ *   - night_pulse_realtime  → city heat score + live count + event spikes + drop badge
+ *   - radio_signals         → WAVE animation (fresh signals only)
+ *   - beacons               → event spike bars (active + ends_at > now)
+ *
+ * Spec: HOTMESS-SoundOfTheNight-LOCKED.docx §6 + §9B / §9D
+ *
+ * Props:
+ *   city        — city slug to display (default: 'london')
+ *   className   — optional wrapper class
+ */
+
+import React, { useEffect, useState, useCallback } from 'react';
+import { supabase } from '@/components/utils/supabaseClient';
+import { useV6Flag } from '@/hooks/useV6Flag';
+import {
+  type NightPulseData,
+  type CityPhase,
+  derivePhase,
+  PHASE_LABEL,
+  isNightPulseFresh,
+  isRadioSignalFresh,
+} from '@/lib/soundOfNight';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface EventSpike {
+  id:        string;
+  title:     string;
+  intensity: number; // 0-1 normalised for bar height
+}
+
+interface RadioWaveState {
+  active:    boolean;
+  intensity: number; // max intensity for animation speed
+}
+
+// ── Refresh interval ──────────────────────────────────────────────────────────
+const REFRESH_MS = 30_000; // re-query every 30s (matview refreshes every 5m)
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+interface Props {
+  city?:      string;
+  className?: string;
+}
+
+export default function PulseModeWidget({ city = 'london', className = '' }: Props) {
+  const flagOn = useV6Flag('v6_sound_of_the_night');
+
+  const [pulse,       setPulse]       = useState<NightPulseData | null>(null);
+  const [radioWave,   setRadioWave]   = useState<RadioWaveState>({ active: false, intensity: 0 });
+  const [eventSpikes, setEventSpikes] = useState<EventSpike[]>([]);
+  const [loading,     setLoading]     = useState(true);
+  const [phase,       setPhase]       = useState<CityPhase>('QUIET');
+
+  const fetchData = useCallback(async () => {
+    if (!flagOn) return;
+
+    try {
+      // 1. night_pulse_realtime — city heat
+      const { data: pulseRows } = await supabase
+        .from('night_pulse_realtime')
+        .select('*')
+        .eq('city', city)
+        .maybeSingle();
+
+      if (pulseRows) {
+        // §9B: stale matview → SPARKLE fallback only
+        const fresh = isNightPulseFresh(pulseRows.refreshed_at);
+        const safePulse: NightPulseData = fresh
+          ? pulseRows
+          : { ...pulseRows, heat_score: 0, live_count: 0, event_spike_count: 0 };
+        setPulse(safePulse);
+        setPhase(derivePhase(safePulse.heat_score));
+      }
+
+      // 2. radio_signals — WAVE animation
+      const { data: radioRows } = await supabase
+        .from('radio_signals')
+        .select('intensity, expires_at')
+        .eq('city', city)
+        .gt('expires_at', new Date().toISOString())
+        .order('created_at', { ascending: false })
+        .limit(5);
+
+      const freshRadio = (radioRows ?? []).filter(r => isRadioSignalFresh(r.expires_at));
+      if (freshRadio.length > 0) {
+        const maxIntensity = Math.max(...freshRadio.map(r => r.intensity ?? 1));
+        setRadioWave({ active: true, intensity: maxIntensity });
+      } else {
+        setRadioWave({ active: false, intensity: 0 });
+      }
+
+      // 3. beacons — event spikes
+      const { data: beaconRows } = await supabase
+        .from('beacons')
+        .select('id, title, intensity')
+        .eq('active', true)
+        .eq('beacon_category', 'event')
+        .eq('city', city)
+        .gt('ends_at', new Date().toISOString())
+        .order('intensity', { ascending: false })
+        .limit(6);
+
+      if (beaconRows && beaconRows.length > 0) {
+        const maxI = Math.max(...beaconRows.map(b => b.intensity ?? 1));
+        setEventSpikes(beaconRows.map(b => ({
+          id:        b.id,
+          title:     b.title ?? '',
+          intensity: maxI > 0 ? (b.intensity ?? 1) / maxI : 0.5,
+        })));
+      } else {
+        setEventSpikes([]);
+      }
+    } catch {
+      // Best-effort — never crash HomeMode
+    } finally {
+      setLoading(false);
+    }
+  }, [flagOn, city]);
+
+  useEffect(() => {
+    if (!flagOn) return;
+    fetchData();
+    const interval = setInterval(fetchData, REFRESH_MS);
+    return () => clearInterval(interval);
+  }, [flagOn, fetchData]);
+
+  // Flag OFF or loading with no data → nothing
+  if (!flagOn) return null;
+  if (loading && !pulse) return null;
+
+  const liveCount     = pulse?.live_count ?? 0;
+  const heatScore     = pulse?.heat_score ?? 0;
+  const dropActive    = pulse?.drop_active ?? false;
+
+  // §9D: no synthetic energy — silent empty state if truly quiet
+  const hasAnything = heatScore > 0 || radioWave.active || eventSpikes.length > 0 || liveCount > 0;
+  if (!hasAnything) return null;
+
+  // Animation speed tied to radio intensity (faster = more intense)
+  const waveSpeed = radioWave.active
+    ? Math.max(0.6, 2.0 - (radioWave.intensity - 1) * 0.5)
+    : 2.0;
+
+  return (
+    <div
+      className={className}
+      style={{
+        backgroundColor: 'rgba(5,5,7,0.92)',
+        border:          '1px solid rgba(200,150,44,0.2)',
+        borderRadius:    '12px',
+        padding:         '12px 16px',
+        backdropFilter:  'blur(12px)',
+      }}
+    >
+      {/* Header row: city label + phase + live count */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{
+            color:       '#C8962C',
+            fontSize:    11,
+            fontFamily:  'Oswald, sans-serif',
+            fontWeight:  700,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+          }}>
+            {city.toUpperCase()}
+          </span>
+          <span style={{
+            color:      'rgba(255,255,255,0.35)',
+            fontSize:   11,
+            fontFamily: 'Oswald, sans-serif',
+          }}>
+            {PHASE_LABEL[phase]}
+          </span>
+        </div>
+
+        {/* Live count — §9D: never show if 0 */}
+        {liveCount > 0 && (
+          <span style={{
+            color:      'rgba(255,255,255,0.6)',
+            fontSize:   11,
+            fontFamily: 'Oswald, sans-serif',
+          }}>
+            {liveCount} live
+          </span>
+        )}
+      </div>
+
+      {/* Heat bar */}
+      <div style={{
+        position:        'relative',
+        height:          4,
+        backgroundColor: 'rgba(255,255,255,0.08)',
+        borderRadius:    2,
+        marginBottom:    10,
+        overflow:        'hidden',
+      }}>
+        <div style={{
+          position:        'absolute',
+          left:            0,
+          top:             0,
+          height:          '100%',
+          width:           `${heatScore}%`,
+          background:      heatScore > 65
+            ? 'linear-gradient(90deg, #C8962C, #FFB84D)'
+            : 'rgba(200,150,44,0.7)',
+          borderRadius:    2,
+          transition:      'width 1s ease',
+        }} />
+      </div>
+
+      {/* Radio WAVE + event spikes row */}
+      <div style={{ display: 'flex', alignItems: 'flex-end', gap: 4, height: 28 }}>
+
+        {/* Radio WAVE — animated bars when active */}
+        {radioWave.active && (
+          <div style={{ display: 'flex', alignItems: 'flex-end', gap: 2, marginRight: 6 }}>
+            {[...Array(4)].map((_, i) => (
+              <div
+                key={i}
+                style={{
+                  width:           3,
+                  backgroundColor: '#C8962C',
+                  borderRadius:    1,
+                  animation:       `soundbar ${waveSpeed}s ease-in-out infinite`,
+                  animationDelay:  `${i * 0.15}s`,
+                  // Heights driven by CSS animation
+                  height:          8 + i * 4,
+                  opacity:         0.6 + i * 0.1,
+                }}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Event spikes — one bar per active event */}
+        {eventSpikes.map(spike => (
+          <div
+            key={spike.id}
+            title={spike.title}
+            style={{
+              width:           6,
+              height:          Math.max(8, Math.round(spike.intensity * 28)),
+              backgroundColor: 'rgba(200,150,44,0.5)',
+              borderRadius:    2,
+              flexShrink:      0,
+            }}
+          />
+        ))}
+
+        {/* Spacer */}
+        <div style={{ flex: 1 }} />
+
+        {/* DROP badge — §9D: only if beacon not expired */}
+        {dropActive && (
+          <span style={{
+            color:        '#C8962C',
+            fontSize:     9,
+            fontFamily:   'Oswald, sans-serif',
+            fontWeight:   700,
+            letterSpacing: '0.1em',
+            border:       '1px solid rgba(200,150,44,0.4)',
+            borderRadius: 4,
+            padding:      '1px 5px',
+          }}>
+            DROP
+          </span>
+        )}
+      </div>
+
+      {/* Soundbar keyframe — injected inline once */}
+      <style>{`
+        @keyframes soundbar {
+          0%, 100% { transform: scaleY(0.4); }
+          50%       { transform: scaleY(1.0); }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/contexts/RadioContext.tsx
+++ b/src/contexts/RadioContext.tsx
@@ -18,6 +18,7 @@ import React, {
 } from 'react';
 import { SoundConsentModal, useSoundConsent } from '@/components/radio/SoundConsentModal';
 import { supabase } from '@/components/utils/supabaseClient';
+import { radioIntensityFromDensity } from '@/lib/soundOfNight';
 
 const STREAM_URL = 'https://listen.radioking.com/radio/736103/stream/802454';
 // Write a radio_signal to DB at most once per 5 minutes per listen session
@@ -56,11 +57,24 @@ export function RadioProvider({ children }: { children: React.ReactNode }) {
 
     try {
       // Best-effort — no auth required (anon signal for aggregate heat)
+      const userCity = 'london'; // default; will be personalised once we have user city
       const expiresAt = new Date(now + 30 * 60 * 1000).toISOString(); // 30 min window
+
+      // Density → radio amplification (spec §5): higher live count = stronger WAVE
+      let intensity = 1;
+      try {
+        const { count } = await supabase
+          .from('right_now_posts')
+          .select('*', { count: 'exact', head: true })
+          .eq('city', userCity)
+          .gt('expires_at', new Date(now).toISOString());
+        intensity = radioIntensityFromDensity(count ?? 0);
+      } catch { /* best-effort — fall back to intensity 1 */ }
+
       await supabase.from('radio_signals').insert({
         signal_type: 'listener_active',
-        city: 'london', // default; will be personalised once we have user city
-        intensity: 1,
+        city: userCity,
+        intensity,
         listener_count_bucket: '1-10',
         starts_at: new Date(now).toISOString(),
         expires_at: expiresAt,

--- a/src/lib/soundOfNight.ts
+++ b/src/lib/soundOfNight.ts
@@ -1,0 +1,184 @@
+/**
+ * src/lib/soundOfNight.ts — Chunk 15
+ *
+ * Sound of the Night: City Phase computation, Signal Priority constants,
+ * and freshness guards for all five cross-system signals.
+ *
+ * Spec: HOTMESS-SoundOfTheNight-LOCKED.docx §9B / §9C / §10
+ * Flag: v6_sound_of_the_night
+ *
+ * No writes. Pure read + derivation utilities.
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** Matches night_pulse_realtime materialized view */
+export interface NightPulseData {
+  city:               string;
+  scans_24h:          number;
+  beacons_active:     number;
+  radio_active:       number;
+  radio_intensity_max: number;
+  live_count:         number;
+  event_spike_count:  number;
+  event_intensity_avg: number;
+  drop_active:        boolean;
+  heat_score:         number;   // 0–100 composite
+  refreshed_at:       string;
+}
+
+/** Derived city phase (client-side) */
+export type CityPhase =
+  | 'QUIET'        // heat 0–20
+  | 'WARMING'      // heat 21–45
+  | 'RISING'       // heat 46–65
+  | 'PEAK'         // heat 66–85
+  | 'OVERDRIVE';   // heat 86–100
+
+/** Sound of the Night signal categories */
+export type SotnSignalType =
+  | 'SAFETY'
+  | 'MEET_TRIGGER'
+  | 'EVENT_PRESENCE'
+  | 'SHARED_LISTENING'
+  | 'RADIO_ATMOSPHERE'
+  | 'MARKET_DROP';
+
+/** A renderable HomeMode / PulseMode signal */
+export interface SotnSignal {
+  type:     SotnSignalType;
+  priority: number;          // 1 = highest (from spec §9C)
+  copy:     string;
+  subCopy?: string;
+}
+
+// ── City Phase ────────────────────────────────────────────────────────────────
+
+/**
+ * Derive city phase from heat_score.
+ * heat_score is a 0-100 composite from night_pulse_realtime.
+ */
+export function derivePhase(heatScore: number): CityPhase {
+  if (heatScore <= 20) return 'QUIET';
+  if (heatScore <= 45) return 'WARMING';
+  if (heatScore <= 65) return 'RISING';
+  if (heatScore <= 85) return 'PEAK';
+  return 'OVERDRIVE';
+}
+
+/** Human-readable phase label */
+export const PHASE_LABEL: Record<CityPhase, string> = {
+  QUIET:     'Quiet',
+  WARMING:   'Warming up',
+  RISING:    'Rising',
+  PEAK:      'Peak',
+  OVERDRIVE: 'On fire',
+};
+
+// ── Signal Priority (spec §9C) ────────────────────────────────────────────────
+
+/** Priority order — lower number = higher priority */
+export const SIGNAL_PRIORITY: Record<SotnSignalType, number> = {
+  SAFETY:            1,
+  MEET_TRIGGER:      2,
+  EVENT_PRESENCE:    3,
+  SHARED_LISTENING:  4,
+  RADIO_ATMOSPHERE:  5,
+  MARKET_DROP:       6,
+};
+
+/** Max visible signals in HomeMode signal line (spec §7) */
+export const HOMEMODE_MAX_SIGNALS = 2;
+
+/**
+ * Sort and cap signals by priority for HomeMode signal line.
+ * Returns at most HOMEMODE_MAX_SIGNALS items, highest priority first.
+ */
+export function rankSignals(signals: SotnSignal[]): SotnSignal[] {
+  return [...signals]
+    .sort((a, b) => a.priority - b.priority)
+    .slice(0, HOMEMODE_MAX_SIGNALS);
+}
+
+// ── Signal Freshness (spec §9B) ───────────────────────────────────────────────
+
+/** Radio signal is fresh if its expires_at is in the future */
+export function isRadioSignalFresh(expiresAt: string): boolean {
+  return new Date(expiresAt).getTime() > Date.now();
+}
+
+/** Beacon is fresh if active AND ends_at is in the future */
+export function isBeaconFresh(active: boolean, endsAt: string): boolean {
+  return active && new Date(endsAt).getTime() > Date.now();
+}
+
+/** right_now_status is fresh if expires_at is in the future */
+export function isRightNowFresh(expiresAt: string): boolean {
+  return new Date(expiresAt).getTime() > Date.now();
+}
+
+/**
+ * night_pulse_realtime heat is considered stale if refreshed_at is
+ * more than 10 minutes ago. Stale → render SPARKLE fallback, not HEAT.
+ * Spec §9B: "globe_heat_tiles window_end within last 10 minutes".
+ */
+export function isNightPulseFresh(refreshedAt: string): boolean {
+  return Date.now() - new Date(refreshedAt).getTime() < 10 * 60 * 1000;
+}
+
+/**
+ * Shared Listening Moment is fresh if:
+ * - track started within last 10 minutes
+ * - both users are online (checked by caller)
+ */
+export function isSharedListeningFresh(trackStartedAt: string): boolean {
+  return Date.now() - new Date(trackStartedAt).getTime() < 10 * 60 * 1000;
+}
+
+// ── Density → Radio Amplification (spec §5) ──────────────────────────────────
+
+/**
+ * Compute radio signal intensity based on city live count.
+ * Used by RadioContext.emitRadioSignal() before inserting into radio_signals.
+ */
+export function radioIntensityFromDensity(rightNowCount: number): number {
+  if (rightNowCount > 50) return 1.5;
+  if (rightNowCount > 20) return 1.2;
+  return 1.0;
+}
+
+// ── HomeMode Signal Builders ──────────────────────────────────────────────────
+
+export function buildRadioEventSignal(showTitle: string, venueName: string): SotnSignal {
+  return {
+    type:     'RADIO_ATMOSPHERE',
+    priority: SIGNAL_PRIORITY.RADIO_ATMOSPHERE,
+    copy:     `On air · playing tonight at ${venueName}`,
+    subCopy:  showTitle,
+  };
+}
+
+export function buildSharedListeningSignal(): SotnSignal {
+  return {
+    type:     'SHARED_LISTENING',
+    priority: SIGNAL_PRIORITY.SHARED_LISTENING,
+    copy:     'Someone nearby is listening to this too',
+  };
+}
+
+export function buildDensityNudgeSignal(liveCount: number): SotnSignal {
+  return {
+    type:     'EVENT_PRESENCE',
+    priority: SIGNAL_PRIORITY.EVENT_PRESENCE,
+    copy:     `${liveCount} men live nearby right now`,
+  };
+}
+
+export function buildDropSignal(): SotnSignal {
+  return {
+    type:     'MARKET_DROP',
+    priority: SIGNAL_PRIORITY.MARKET_DROP,
+    copy:     'Need lube?',
+    subCopy:  'Drop live now',
+  };
+}


### PR DESCRIPTION
Flag: `v6_sound_of_the_night` (default OFF)

**DB (already applied via Supabase MCP)**
- `night_pulse_realtime` materialized view: city heat_score, live_count, radio_active, event_spike_count, drop_active
- `refresh_night_pulse()` function + pg_cron every 5 min
- `beacons.radio_show_id` UUID FK → `radio_shows` (ON DELETE SET NULL)

**New: `src/lib/soundOfNight.ts`**
- `NightPulseData` — typed interface matching `night_pulse_realtime` matview
- `derivePhase(heatScore)` — QUIET/WARMING/RISING/PEAK/OVERDRIVE from 0-100
- `SIGNAL_PRIORITY` constants per spec §9C (Safety=1 … Market=6)
- `rankSignals()` — sort + cap to HOMEMODE_MAX_SIGNALS=2
- `isRadioSignalFresh / isBeaconFresh / isRightNowFresh / isNightPulseFresh / isSharedListeningFresh` — spec §9B
- `radioIntensityFromDensity(count)` — 1.0/1.2/1.5 based on live count thresholds
- `buildRadioEventSignal / buildSharedListeningSignal / buildDensityNudgeSignal / buildDropSignal` — HomeMode signal builders

**New: `src/components/home/PulseModeWidget.tsx`**
- Flag-gated: `v6_sound_of_the_night` OFF → renders nothing
- Reads `night_pulse_realtime` for heat bar + live count + phase label
- Reads `radio_signals` for WAVE animation (animated bars, speed tied to intensity)
- Reads `beacons` (active + event category) for event spike bars
- DROP badge from `night_pulse_realtime.drop_active` (only if beacon live)
- §9D: no synthetic energy — returns null if everything is zero
- §9B: stale matview (>10min) → heat/count zeroed, renders SPARKLE fallback only

**Updated: `src/contexts/RadioContext.tsx`**
- Imports `radioIntensityFromDensity` from `@/lib/soundOfNight`
- `emitRadioSignal()`: queries `right_now_posts` COUNT for city before writing radio_signal
- Intensity: 1.0 (<20 live), 1.2 (21-50 live), 1.5 (>50 live) — spec §5
- Fail-open: COUNT query error → intensity 1.0 (never blocks playback)
