### PR TITLE
feat(chunk-16): HNH MESS GTM

### DIFF
--- a/api/stripe/create-checkout-session.js
+++ b/api/stripe/create-checkout-session.js
@@ -93,6 +93,81 @@ export default async function handler(req, res) {
     .eq('id', user.id)
     .single();
 
+  // ── HNH MESS product checkout (Channel 2/3: direct Stripe, no Shopify required) ─────────
+  if (type === 'hnh_mess') {
+    const {
+      sku = 'small',           // 'small' (£10) | 'large' (£15)
+      source,                  // attribution: market | beacon | radio | home | chat | whatsapp | venue_physical
+      venue_id   = null,
+      beacon_id  = null,
+      radio_show_id = null,
+    } = body;
+
+    // Daily order cap — spec §STOCK SAFETY (default 20)
+    const maxDaily = Number(process.env.MAX_HNH_DAILY_ORDERS ?? 20);
+    const todayStart = new Date();
+    todayStart.setHours(0, 0, 0, 0);
+
+    const { count: todayCount } = await supabase
+      .from('orders')
+      .select('*', { count: 'exact', head: true })
+      .eq('product_key', 'hnh-mess')
+      .gte('created_at', todayStart.toISOString());
+
+    if ((todayCount ?? 0) >= maxDaily) {
+      res.statusCode = 429;
+      return res.end(JSON.stringify({
+        error: 'Daily order cap reached. Back soon.',
+        code:  'HNH_DAILY_CAP',
+      }));
+    }
+
+    const priceGbp = sku === 'large' ? 15 : 10;
+    const productName = sku === 'large' ? 'HNH MESS Large (50ml)' : 'HNH MESS Small (30ml)';
+
+    try {
+      const session = await stripe.checkout.sessions.create({
+        ui_mode: 'embedded',
+        payment_method_types: ['card'],
+        mode: 'payment',
+        customer_email: user.email,
+        line_items: [{
+          price_data: {
+            currency: 'gbp',
+            unit_amount: priceGbp * 100,
+            product_data: {
+              name: productName,
+              description: 'Aftercare isn\'t optional. Premium water-based lube.',
+            },
+          },
+          quantity: 1,
+        }],
+        shipping_address_collection: { allowed_countries: ['GB'] },
+        metadata: {
+          user_id:       user.id,
+          user_email:    user.email ?? '',
+          user_name:     profile?.display_name ?? '',
+          type:          'hnh_mess',
+          product_key:   'hnh-mess',
+          sku,
+          source:        source ?? 'unknown',
+          venue_id:      venue_id   ? String(venue_id)    : '',
+          beacon_id:     beacon_id  ? String(beacon_id)   : '',
+          radio_show_id: radio_show_id ? String(radio_show_id) : '',
+        },
+        return_url: `${origin}/market?purchase=success&type=hnh_mess&session_id={CHECKOUT_SESSION_ID}`,
+        allow_promotion_codes: false,
+      });
+
+      res.statusCode = 200;
+      return res.end(JSON.stringify({ clientSecret: session.client_secret }));
+    } catch (err) {
+      console.error('[hnh_mess-checkout] Stripe error:', err?.message);
+      res.statusCode = 500;
+      return res.end(JSON.stringify({ error: 'Failed to create checkout session', detail: err?.message }));
+    }
+  }
+
   // ── Preloved or Shopify order checkout ──────────────────────────────────────────────
   if (type === 'preloved_order' || type === 'shopify_order') {
     const { listing_id, price_gbp, title, order_id, items: lineItems } = body;

--- a/api/stripe/webhook.js
+++ b/api/stripe/webhook.js
@@ -186,6 +186,73 @@ async function processOrderCompletion(session, eventType, req) {
     return;
   }
 
+  // ── HNH MESS direct purchase completion ──────────────────────────────────
+  if (session.metadata?.type === 'hnh_mess') {
+    const userId      = session.metadata?.user_id ?? null;
+    const source      = session.metadata?.source ?? 'unknown';
+    const venueId     = session.metadata?.venue_id   || null;
+    const beaconId    = session.metadata?.beacon_id  || null;
+    const radioShowId = session.metadata?.radio_show_id || null;
+    const sku         = session.metadata?.sku ?? 'small';
+    const amountGbp   = (session.amount_total ?? 0) / 100;
+
+    // Write order row with attribution metadata
+    const { data: orderRow, error: orderErr } = await supabase
+      .from('orders')
+      .insert({
+        user_id:     userId,
+        product_key: 'hnh-mess',
+        sku,
+        amount:      amountGbp,
+        currency:    'gbp',
+        status:      'paid',
+        stripe_session_id: session.id,
+        buyer_email: session.customer_details?.email ?? session.metadata?.user_email ?? '',
+        buyer_name:  session.customer_details?.name  ?? session.metadata?.user_name  ?? '',
+        shipping_address: session.shipping_details
+          ? `${session.shipping_details.name}
+${session.shipping_details.address.line1}, ${session.shipping_details.address.city}, ${session.shipping_details.address.postal_code}`
+          : null,
+        metadata: {
+          source,
+          venue_id:      venueId,
+          beacon_id:     beaconId,
+          radio_show_id: radioShowId,
+        },
+      })
+      .select('id')
+      .single();
+
+    if (orderErr) {
+      console.error('[hnh_mess-webhook] order insert error:', orderErr.message);
+    } else {
+      console.log('[hnh_mess-webhook] order created:', orderRow?.id);
+    }
+
+    // Write attribution event to analytics_events
+    if (userId) {
+      await supabase.from('analytics_events').insert({
+        user_id:    userId,
+        event_name: 'hnh_purchase',
+        category:   'conversion',
+        label:      `hnh_mess_${sku}`,
+        value:      amountGbp,
+        properties: {
+          source,
+          sku,
+          venue_id:      venueId,
+          beacon_id:     beaconId,
+          radio_show_id: radioShowId,
+          stripe_session_id: session.id,
+          order_id:      orderRow?.id ?? null,
+        },
+      });
+    }
+
+    console.log(`[hnh_mess-webhook] Done. source=${source} sku=${sku} amount=£${amountGbp}`);
+    return;
+  }
+
   // ── Handle Physical Orders (Existing Logic) ──────────────────────────────
   if (!orderId) {
     console.warn('[Webhook] No orderId found in metadata. Skipping processing.');

--- a/src/components/home/HNHProximityCard.tsx
+++ b/src/components/home/HNHProximityCard.tsx
@@ -1,0 +1,153 @@
+/**
+ * src/components/home/HNHProximityCard.tsx — Chunk 16
+ *
+ * HomeMode signal-line card: "Need lube?"
+ * Appears when user is at a known London venue AND HNH stock > 0 in city.
+ *
+ * Flag-gated: v6_hnh_mess_gtm
+ *
+ * Spec: HOTMESS-HNHMess-GTM-LOCKED.docx Channel 3
+ * Signal priority 6 (MARKET_DROP) — lowest, never displaces safety/meet/social signals.
+ *
+ * Props:
+ *   venueName   — from right_now_status.venue_name (caller provides)
+ *   onShopTap   — callback to open checkout/market
+ *   className   — optional wrapper class
+ */
+
+import React, { useEffect, useState } from 'react';
+import { supabase } from '@/components/utils/supabaseClient';
+import { useV6Flag } from '@/hooks/useV6Flag';
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+// London venue slugs that trigger the card (must be in venues table)
+const LONDON_VENUE_SLUGS = [
+  'eagle-london',
+  'vauxhall-tavern',
+  'ku-bar',
+  'heaven-nightclub',
+  'the-glory',
+  'dalston-superstore',
+  'adonis-london',
+];
+
+const HNH_PRODUCT_KEY = 'hnh-mess';
+const GOLD = '#C8962C';
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+interface Props {
+  venueName?: string | null;
+  onShopTap:  () => void;
+  className?: string;
+}
+
+export default function HNHProximityCard({ venueName, onShopTap, className = '' }: Props) {
+  const flagOn = useV6Flag('v6_hnh_mess_gtm');
+  const [hasStock, setHasStock]   = useState(false);
+  const [beaconId, setBeaconId]   = useState<string | null>(null);
+  const [venueId,  setVenueId]    = useState<string | null>(null);
+  const [checked,  setChecked]    = useState(false);
+
+  useEffect(() => {
+    if (!flagOn || !venueName) { setChecked(true); return; }
+
+    async function checkStockAndVenue() {
+      try {
+        // 1. Resolve venue record from name or slug match
+        const { data: venue } = await supabase
+          .from('venues')
+          .select('id, slug')
+          .or(`name.ilike.%${venueName}%,slug.ilike.%${venueName?.toLowerCase().replace(/\s+/g, '-')}%`)
+          .limit(1)
+          .maybeSingle();
+
+        if (!venue) { setChecked(true); return; }
+
+        // Only trigger for London target venues
+        const isTarget = LONDON_VENUE_SLUGS.some(s =>
+          venue.slug?.includes(s) || s.includes(venue.slug)
+        );
+        if (!isTarget) { setChecked(true); return; }
+
+        setVenueId(venue.id);
+
+        // 2. Check for active MARKET beacon at this venue (stock indicator)
+        const { data: beacon } = await supabase
+          .from('beacons')
+          .select('id')
+          .eq('venue_id', venue.id)
+          .eq('active', true)
+          .eq('beacon_category', 'system')
+          .gt('ends_at', new Date().toISOString())
+          .limit(1)
+          .maybeSingle();
+
+        setBeaconId(beacon?.id ?? null);
+        setHasStock(!!beacon); // beacon presence = stock confirmed in venue tonight
+      } catch {
+        // best-effort
+      } finally {
+        setChecked(true);
+      }
+    }
+
+    checkStockAndVenue();
+  }, [flagOn, venueName]);
+
+  // §9D-equivalent: never show if stock not confirmed
+  if (!flagOn || !checked || !hasStock) return null;
+
+  return (
+    <button
+      onClick={onShopTap}
+      data-hnh-venue-id={venueId ?? undefined}
+      data-hnh-beacon-id={beaconId ?? undefined}
+      className={`w-full flex items-center gap-3 text-left active:opacity-70 transition-opacity ${className}`}
+      style={{
+        padding:         '10px 16px',
+        background:      'linear-gradient(90deg, #0D0800 0%, #1A1000 100%)',
+        border:          `1px solid ${GOLD}30`,
+        borderRadius:    10,
+      }}
+    >
+      {/* Gold dot signal indicator */}
+      <div style={{
+        width:           8,
+        height:          8,
+        borderRadius:    '50%',
+        backgroundColor: GOLD,
+        flexShrink:      0,
+        boxShadow:       `0 0 6px ${GOLD}`,
+      }} />
+
+      {/* Copy */}
+      <div className="flex-1 min-w-0">
+        <p style={{ color: 'rgba(255,255,255,0.85)', fontSize: 13, fontWeight: 600, margin: 0 }}>
+          Need lube?
+        </p>
+        <p style={{ color: 'rgba(255,255,255,0.35)', fontSize: 11, margin: '1px 0 0' }}>
+          HNH MESS at the bar tonight
+        </p>
+      </div>
+
+      {/* CTA badge */}
+      <span style={{
+        flexShrink:      0,
+        fontSize:        10,
+        fontWeight:      700,
+        fontFamily:      'Oswald, sans-serif',
+        letterSpacing:   '0.08em',
+        textTransform:   'uppercase',
+        padding:         '3px 8px',
+        borderRadius:    6,
+        backgroundColor: `${GOLD}20`,
+        border:          `1px solid ${GOLD}50`,
+        color:           GOLD,
+      }}>
+        Shop
+      </span>
+    </button>
+  );
+}

--- a/src/components/radio/HNHRadioCard.tsx
+++ b/src/components/radio/HNHRadioCard.tsx
@@ -1,0 +1,118 @@
+/**
+ * src/components/radio/HNHRadioCard.tsx — Chunk 16
+ *
+ * HNH MESS sponsorship card in RadioMode — shown during Dial-A-Daddy show.
+ * Flag-gated: v6_hnh_mess_gtm
+ *
+ * Spec: HOTMESS-HNHMess-GTM-LOCKED.docx Channel 4
+ * Copy: "Daddy's listening. Be prepared."
+ * CTA: direct Stripe checkout (radio attribution source)
+ *
+ * Props:
+ *   showName   — current show name (from RadioContext.currentShowName)
+ *   radioShowId — UUID of the active radio show (for attribution)
+ *   onShopTap  — open HNH checkout (caller passes source='radio', radio_show_id)
+ */
+
+import React from 'react';
+import { useV6Flag } from '@/hooks/useV6Flag';
+
+// Show name patterns that trigger the card
+const HNH_SPONSORED_SHOWS = ['dial-a-daddy', 'dial a daddy', 'dialadaddy'];
+
+const GOLD    = '#C8962C';
+const BOTTLE  = 'https://cdn.shopify.com/s/files/1/0629/2497/4961/files/hnh-mess-50ml.png';
+
+interface Props {
+  showName?:   string;
+  radioShowId?: string | null;
+  onShopTap:   (radioShowId: string | null) => void;
+  className?:  string;
+}
+
+export default function HNHRadioCard({ showName, radioShowId, onShopTap, className = '' }: Props) {
+  const flagOn = useV6Flag('v6_hnh_mess_gtm');
+
+  if (!flagOn) return null;
+  if (!showName) return null;
+
+  const isSponsored = HNH_SPONSORED_SHOWS.some(s =>
+    showName.toLowerCase().includes(s)
+  );
+  if (!isSponsored) return null;
+
+  return (
+    <div
+      className={`w-full ${className}`}
+      style={{
+        background:   'linear-gradient(135deg, #0A0800 0%, #150F00 100%)',
+        border:       `1px solid ${GOLD}25`,
+        borderRadius: 10,
+        padding:      '12px 14px',
+        display:      'flex',
+        alignItems:   'center',
+        gap:          12,
+      }}
+    >
+      {/* Bottle image */}
+      <img
+        src={BOTTLE}
+        alt="HNH MESS"
+        style={{ width: 44, height: 54, objectFit: 'contain', flexShrink: 0 }}
+        onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+      />
+
+      {/* Copy */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <p style={{
+          color:        GOLD,
+          fontSize:     9,
+          fontFamily:   'Oswald, sans-serif',
+          fontWeight:   700,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          margin:       '0 0 3px',
+        }}>
+          Sponsored
+        </p>
+        <p style={{
+          color:      'rgba(255,255,255,0.85)',
+          fontSize:   14,
+          fontWeight: 600,
+          margin:     '0 0 2px',
+          fontFamily: 'Oswald, sans-serif',
+        }}>
+          HNH MESS
+        </p>
+        <p style={{
+          color:    'rgba(255,255,255,0.45)',
+          fontSize: 12,
+          margin:   0,
+        }}>
+          Daddy&apos;s listening. Be prepared.
+        </p>
+      </div>
+
+      {/* Shop CTA */}
+      <button
+        onClick={() => onShopTap(radioShowId ?? null)}
+        style={{
+          flexShrink:      0,
+          padding:         '8px 14px',
+          borderRadius:    8,
+          backgroundColor: `${GOLD}18`,
+          border:          `1px solid ${GOLD}50`,
+          color:           GOLD,
+          fontSize:        12,
+          fontFamily:      'Oswald, sans-serif',
+          fontWeight:      700,
+          letterSpacing:   '0.06em',
+          textTransform:   'uppercase',
+          cursor:          'pointer',
+        }}
+      >
+        Shop
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
Flag: `v6_hnh_mess_gtm` (default OFF)

**New: `src/components/home/HNHProximityCard.tsx`**
- Flag-gated: `v6_hnh_mess_gtm` OFF → renders nothing
- Checks user venue (from right_now_status.venue_name) against London target venues (Eagle, Tavern, etc.)
- Queries active MARKET beacon at venue → beacon presence confirms stock tonight
- §9D-equivalent: never renders if stock not confirmed
- Emits `venue_id` + `beacon_id` for attribution on tap

**New: `src/components/radio/HNHRadioCard.tsx`**
- Flag-gated: `v6_hnh_mess_gtm` OFF → renders nothing
- Shows only during Dial-A-Daddy show (show name match)
- Copy: "Daddy's listening. Be prepared."
- Passes `radio_show_id` to checkout for attribution

**Updated: `api/stripe/create-checkout-session.js`**
- New type: `hnh_mess` — direct Stripe checkout (no Shopify required)
- SKU: `small` (£10) | `large` (£15)
- Attribution metadata: `source`, `venue_id`, `beacon_id`, `radio_show_id`
- Daily cap: `MAX_HNH_DAILY_ORDERS` env var (default 20) — returns 429 if hit
- Shipping address collection enabled (GB only)

**Updated: `api/stripe/webhook.js`**
- Handles `hnh_mess` type in `checkout.session.completed`
- Inserts to `orders` table with `product_key=hnh-mess`, `metadata` JSONB attribution
- Writes `hnh_purchase` event to `analytics_events` with full attribution properties
- Attribution fields: `source`, `sku`, `venue_id`, `beacon_id`, `radio_show_id`, `stripe_session_id`, `order_id`
- Returns early — does not run existing Shopify mirror / preloved email flows
