### PR TITLE
feat(chunk-17c): Analytics Instrumentation

### DIFF
--- a/api/analytics/track.js
+++ b/api/analytics/track.js
@@ -1,0 +1,58 @@
+/**
+ * api/analytics/track.js — Chunk 17c
+ *
+ * Receives client-side analytics events and inserts into analytics_events.
+ * Accepts anonymous events (user_id resolved from JWT if present).
+ *
+ * POST /api/analytics/track
+ * Body: { event_name, category?, label?, value?, properties? }
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+);
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'method not allowed' });
+  }
+
+  const { event_name, category, label, value, properties } = req.body ?? {};
+
+  if (!event_name || typeof event_name !== 'string') {
+    return res.status(400).json({ error: 'event_name required' });
+  }
+
+  // Optionally resolve user from JWT — anonymous events are allowed
+  let userId = null;
+  const authHeader = req.headers['authorization'] ?? '';
+  const jwt = authHeader.replace('Bearer ', '').trim();
+  if (jwt) {
+    const { data: { user } } = await supabase.auth.getUser(jwt).catch(() => ({ data: { user: null } }));
+    userId = user?.id ?? null;
+  }
+
+  const row = {
+    event_name,
+    category:   category ?? null,
+    label:      label ?? null,
+    value:      typeof value === 'number' ? value : null,
+    properties: properties ?? null,
+    user_id:    userId,
+    path:       req.headers['referer'] ?? null,
+    user_agent: req.headers['user-agent'] ?? null,
+    created_at: new Date().toISOString(),
+  };
+
+  const { error } = await supabase.from('analytics_events').insert(row);
+
+  if (error) {
+    // Log but return 200 — client should never retry analytics
+    console.error('[analytics/track] insert error:', error.message, { event_name });
+  }
+
+  return res.status(200).json({ ok: true });
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,6 +80,7 @@ const VaultMode   = lazy(() => import('@/modes/VaultMode'));
 const ChatMeetupPage = lazy(() => import('@/pages/ChatMeetupPage'));
 const ModerationPage = lazy(() => import('@/pages/admin/ModerationPage'));
 const FlagsAdmin    = lazy(() => import('@/pages/admin/FlagsAdmin'));
+const FunnelPage    = lazy(() => import('@/pages/admin/FunnelPage'));
 const SOSPage = lazy(() => import('@/pages/SOSPage'));
 const FakeCallPage = lazy(() => import('@/pages/FakeCallPage'));
 const SafetyPage = lazy(() => import('@/pages/Safety'));
@@ -496,6 +497,8 @@ const AuthenticatedApp = () => {
       
       {/* ADMIN — v6 Feature Flags */}
       <Route path="/admin/flags" element={<Suspense fallback={<PageLoadingSkeleton type="feed" />}><FlagsAdmin /></Suspense>} />
+      {/* ADMIN — v6 Funnel Dashboard */}
+      <Route path="/admin/funnel" element={<Suspense fallback={<PageLoadingSkeleton type="feed" />}><FunnelPage /></Suspense>} />
       <Route path="*" element={<PageNotFound />} />
       </Routes>
     </PageTransition>

--- a/src/components/onboarding/OnboardingRouter.jsx
+++ b/src/components/onboarding/OnboardingRouter.jsx
@@ -20,6 +20,7 @@
  */
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useV6Flag as useFlag } from '@/hooks/useV6Flag';
+import { track } from '@/lib/analytics';
 import First5MinutesFlow from './First5MinutesFlow';
 
 import { useNavigate } from 'react-router-dom';
@@ -295,16 +296,20 @@ export default function OnboardingRouter() {
 
   const handleQuickSetupComplete = () => {
     // QuickSetup done → advance to Profile details screen
+    track('onboarding_stage_completed', 'onboarding', 'quick_setup');
     goTo(SCREENS.PROFILE);
   };
 
   const handleProfileComplete = () => {
     // Profile details done → advance to PIN setup
+    track('onboarding_stage_completed', 'onboarding', 'profile_complete');
     goTo(SCREENS.PIN_SETUP);
   };
 
   const handlePinComplete = async () => {
     // PIN is the final step — onboarding_completed is now true in DB
+    track('onboarding_stage_completed', 'onboarding', 'pin_complete');
+    track('profile_complete', 'onboarding');
     if (refetchProfile) {
       await refetchProfile();
     }

--- a/src/components/onboarding/screens/AgeGateScreen.jsx
+++ b/src/components/onboarding/screens/AgeGateScreen.jsx
@@ -4,6 +4,7 @@
  */
 import React, { useState } from 'react';
 import BlockedScreen from './BlockedScreen';
+import { track } from '@/lib/analytics';
 
 const GOLD = '#C8962C';
 
@@ -30,6 +31,8 @@ export default function AgeGateScreen({ onComplete }) {
   const handleContinue = () => {
     if (!confirmed) return;
     try { localStorage.setItem('hm_age_gate_passed', 'true'); } catch {}
+    // Chunk 17c: instrument age gate pass
+    track('age_gate_passed', 'onboarding');
     onComplete();
   };
 

--- a/src/components/onboarding/screens/SignUpScreen.jsx
+++ b/src/components/onboarding/screens/SignUpScreen.jsx
@@ -15,6 +15,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { supabase } from '@/components/utils/supabaseClient';
 import { Loader2, Mail } from 'lucide-react';
 import { ProgressDots } from './AgeGateScreen';
+import { track } from '@/lib/analytics';
 
 const GOLD = '#C8962C';
 
@@ -60,6 +61,8 @@ export default function SignUpScreen({ isSignIn = false }) {
   const handleOAuth = async (provider) => {
     setLoading(true);
     setError('');
+    // Chunk 17c: track signup attempt before redirect
+    track('signup', 'onboarding', provider);
     const { error: oauthError } = await supabase.auth.signInWithOAuth({
       provider,
       options: {
@@ -92,6 +95,8 @@ export default function SignUpScreen({ isSignIn = false }) {
     if (otpError) {
       setError(otpError.message);
     } else {
+      // Chunk 17c: track magic link signup
+      track('signup', 'onboarding', 'magic_link');
       setMagicLinkSent(true);
       setCountdown(RESEND_COOLDOWN);
     }

--- a/src/hooks/useV6Flag.js
+++ b/src/hooks/useV6Flag.js
@@ -13,6 +13,8 @@ import { useQuery } from '@tanstack/react-query';
 import { useAuth } from '@/lib/AuthContext';
 import { supabase } from '@/components/utils/supabaseClient';
 import { resolveFlag } from '@/lib/v6Flags';
+import { useEffect, useRef } from 'react';
+import { trackOnce } from '@/lib/analytics';
 
 // Fetch current user's role once (cached alongside flag resolution)
 async function fetchUserRole(userId) {
@@ -42,7 +44,22 @@ export function useV6Flag(flagKey) {
     refetchOnWindowFocus: true,
   });
 
-  return data ?? false;
+  const flagValue = data ?? false;
+
+  // Chunk 17c: fire flag_exposure once per session when flag resolves to true
+  useEffect(() => {
+    if (!flagValue || !userId) return;
+    trackOnce(
+      `flag_exposure:${flagKey}:${userId}`,
+      'flag_exposure',
+      'flags',
+      flagKey,
+      undefined,
+      { flag_key: flagKey, user_id: userId },
+    );
+  }, [flagValue, flagKey, userId]);
+
+  return flagValue;
 }
 
 export default useV6Flag;

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,61 @@
+/**
+ * src/lib/analytics.ts — Chunk 17c
+ *
+ * Client-side analytics helper. Fire-and-forget POST to /api/analytics/track.
+ * Never blocks rendering. Never throws to callers.
+ *
+ * Usage:
+ *   import { track } from '@/lib/analytics';
+ *   track('signup', 'onboarding', 'google_oauth');
+ *   track('flag_exposure', 'flags', undefined, undefined, { flag_key: 'v6_aa_system' });
+ */
+
+export interface TrackEvent {
+  event_name:  string;
+  category?:   string;
+  label?:      string;
+  value?:      number;
+  properties?: Record<string, unknown>;
+}
+
+/**
+ * track — send a single analytics event.
+ * Errors are swallowed — analytics must never disrupt user flow.
+ */
+export function track(
+  event_name: string,
+  category?:  string,
+  label?:     string,
+  value?:     number,
+  properties?: Record<string, unknown>,
+): void {
+  const payload: TrackEvent = { event_name, category, label, value, properties };
+
+  // Best-effort POST — no await, no catch bubbling
+  fetch('/api/analytics/track', {
+    method:  'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body:    JSON.stringify(payload),
+    // keepalive allows the request to outlive page unload
+    keepalive: true,
+  }).catch(() => { /* swallow — analytics must not disrupt UX */ });
+}
+
+/**
+ * trackOnce — send an event only once per session per key.
+ * Useful for flag_exposure and first_* events to avoid flooding.
+ */
+const _sent = new Set<string>();
+
+export function trackOnce(
+  dedupeKey:   string,
+  event_name:  string,
+  category?:   string,
+  label?:      string,
+  value?:      number,
+  properties?: Record<string, unknown>,
+): void {
+  if (_sent.has(dedupeKey)) return;
+  _sent.add(dedupeKey);
+  track(event_name, category, label, value, properties);
+}

--- a/src/pages/admin/FunnelPage.jsx
+++ b/src/pages/admin/FunnelPage.jsx
@@ -1,0 +1,232 @@
+/**
+ * src/pages/admin/FunnelPage.jsx — Chunk 17c
+ *
+ * Funnel dashboard at /admin/funnel.
+ * Reads analytics_events via Supabase service-role RPC or direct query.
+ * Admin-only: requires profiles.role = 'admin' | 'superadmin'.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { supabase } from '@/components/utils/supabaseClient';
+import { useUserContext } from '@/hooks/useUserContext';
+import { useNavigate } from 'react-router-dom';
+
+const GOLD  = '#C8962C';
+const BG    = '#050507';
+const CARD  = '#0D0D0F';
+
+const FUNNEL_STEPS = [
+  { key: 'age_gate_passed',          label: 'Age Gate Passed',         category: 'onboarding' },
+  { key: 'signup',                    label: 'Signed Up',               category: 'onboarding' },
+  { key: 'onboarding_stage_completed',label: 'Onboarding Stage Done',   category: 'onboarding' },
+  { key: 'profile_complete',          label: 'Profile Complete',        category: 'onboarding' },
+  { key: 'first_message_sent',        label: 'First Message Sent',      category: 'activation' },
+  { key: 'first_meet_committed',      label: 'First Meet Committed',    category: 'activation' },
+  { key: 'first_purchase',            label: 'First Purchase',          category: 'conversion' },
+];
+
+const FLAG_EXPOSURE_KEY = 'flag_exposure';
+
+export default function FunnelPage() {
+  const { profile } = useUserContext();
+  const navigate    = useNavigate();
+
+  const [counts,       setCounts]       = useState({});
+  const [flagCounts,   setFlagCounts]   = useState([]);
+  const [dateRange,    setDateRange]    = useState(7); // days
+  const [loading,      setLoading]      = useState(true);
+  const [error,        setError]        = useState(null);
+
+  // Gate: admin / superadmin only
+  useEffect(() => {
+    if (!profile) return;
+    if (!['admin', 'superadmin'].includes(profile.role)) {
+      navigate('/');
+    }
+  }, [profile, navigate]);
+
+  useEffect(() => {
+    loadData();
+  }, [dateRange]);
+
+  async function loadData() {
+    setLoading(true);
+    setError(null);
+    try {
+      const since = new Date(Date.now() - dateRange * 86400 * 1000).toISOString();
+
+      // ── Funnel event counts (unique users per event) ──────────────────────
+      const { data: rows, error: qErr } = await supabase
+        .from('analytics_events')
+        .select('event_name, user_id')
+        .in('event_name', FUNNEL_STEPS.map(s => s.key))
+        .gte('created_at', since);
+
+      if (qErr) throw qErr;
+
+      const newCounts = {};
+      for (const step of FUNNEL_STEPS) {
+        const stepRows = rows.filter(r => r.event_name === step.key);
+        const unique   = new Set(stepRows.map(r => r.user_id)).size;
+        const total    = stepRows.length;
+        newCounts[step.key] = { unique, total };
+      }
+      setCounts(newCounts);
+
+      // ── Flag exposure counts ──────────────────────────────────────────────
+      const { data: flagRows, error: fErr } = await supabase
+        .from('analytics_events')
+        .select('properties')
+        .eq('event_name', FLAG_EXPOSURE_KEY)
+        .gte('created_at', since);
+
+      if (fErr) throw fErr;
+
+      const flagMap = {};
+      for (const r of flagRows) {
+        const key = r.properties?.flag_key;
+        if (key) flagMap[key] = (flagMap[key] ?? 0) + 1;
+      }
+      const sorted = Object.entries(flagMap)
+        .sort((a, b) => b[1] - a[1])
+        .map(([flag_key, exposures]) => ({ flag_key, exposures }));
+      setFlagCounts(sorted);
+
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const firstCount  = counts['age_gate_passed']?.unique ?? 0;
+
+  return (
+    <div style={{ minHeight: '100vh', background: BG, color: '#fff', padding: '24px 16px', fontFamily: 'Barlow, sans-serif' }}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 24 }}>
+        <div>
+          <h1 style={{ fontSize: 22, fontFamily: 'Oswald, sans-serif', fontWeight: 700, color: GOLD, margin: 0 }}>
+            FUNNEL
+          </h1>
+          <p style={{ fontSize: 12, color: 'rgba(255,255,255,0.4)', margin: '2px 0 0' }}>
+            Analytics · v6 Build
+          </p>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          {[7, 14, 30].map(d => (
+            <button
+              key={d}
+              onClick={() => setDateRange(d)}
+              style={{
+                padding:         '6px 12px',
+                borderRadius:    '8px',
+                fontSize:        12,
+                fontFamily:      'Oswald, sans-serif',
+                fontWeight:      600,
+                cursor:          'pointer',
+                backgroundColor: dateRange === d ? GOLD : 'rgba(255,255,255,0.05)',
+                color:           dateRange === d ? '#000' : 'rgba(255,255,255,0.6)',
+                border:          'none',
+              }}
+            >
+              {d}d
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <div style={{ padding: '12px 16px', background: 'rgba(255,60,60,0.1)', borderRadius: 8, color: '#ff6b6b', marginBottom: 16, fontSize: 13 }}>
+          {error}
+        </div>
+      )}
+
+      {/* Funnel steps */}
+      <div style={{ marginBottom: 32 }}>
+        <h2 style={{ fontSize: 11, letterSpacing: '0.1em', color: 'rgba(255,255,255,0.4)', textTransform: 'uppercase', marginBottom: 12 }}>
+          Acquisition Funnel
+        </h2>
+        {FUNNEL_STEPS.map((step, i) => {
+          const { unique = 0, total = 0 } = counts[step.key] ?? {};
+          const pct = firstCount > 0 ? Math.round((unique / firstCount) * 100) : 0;
+          const prevStep = i > 0 ? FUNNEL_STEPS[i - 1] : null;
+          const prevUnique = prevStep ? (counts[prevStep.key]?.unique ?? 0) : firstCount;
+          const dropPct = prevUnique > 0 ? Math.round(((prevUnique - unique) / prevUnique) * 100) : 0;
+
+          return (
+            <div
+              key={step.key}
+              style={{
+                background:    CARD,
+                border:        '1px solid rgba(255,255,255,0.06)',
+                borderRadius:  10,
+                padding:       '14px 16px',
+                marginBottom:  8,
+                position:      'relative',
+                overflow:      'hidden',
+              }}
+            >
+              {/* progress fill */}
+              <div style={{
+                position:        'absolute',
+                top: 0, left: 0, bottom: 0,
+                width:           `${pct}%`,
+                backgroundColor: 'rgba(200,150,44,0.08)',
+                transition:      'width 0.4s ease',
+              }} />
+
+              <div style={{ position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                <div>
+                  <p style={{ fontSize: 13, fontWeight: 600, margin: 0 }}>{step.label}</p>
+                  <p style={{ fontSize: 11, color: 'rgba(255,255,255,0.3)', margin: '2px 0 0', letterSpacing: '0.03em' }}>
+                    {step.key}
+                  </p>
+                </div>
+                <div style={{ textAlign: 'right' }}>
+                  <p style={{ fontSize: 18, fontFamily: 'Oswald, sans-serif', fontWeight: 700, color: GOLD, margin: 0 }}>
+                    {loading ? '—' : unique.toLocaleString()}
+                    <span style={{ fontSize: 11, color: 'rgba(255,255,255,0.3)', marginLeft: 6 }}>uniq</span>
+                  </p>
+                  <p style={{ fontSize: 11, color: 'rgba(255,255,255,0.3)', margin: '2px 0 0' }}>
+                    {loading ? '' : `${pct}% of top${i > 0 && dropPct > 0 ? ` · −${dropPct}% step` : ''}`}
+                  </p>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Flag exposures */}
+      {flagCounts.length > 0 && (
+        <div>
+          <h2 style={{ fontSize: 11, letterSpacing: '0.1em', color: 'rgba(255,255,255,0.4)', textTransform: 'uppercase', marginBottom: 12 }}>
+            Flag Exposures ({dateRange}d)
+          </h2>
+          <div style={{ background: CARD, border: '1px solid rgba(255,255,255,0.06)', borderRadius: 10, overflow: 'hidden' }}>
+            {flagCounts.map((row, i) => (
+              <div
+                key={row.flag_key}
+                style={{
+                  display:       'flex',
+                  alignItems:    'center',
+                  justifyContent:'space-between',
+                  padding:       '12px 16px',
+                  borderTop:     i > 0 ? '1px solid rgba(255,255,255,0.04)' : 'none',
+                }}
+              >
+                <p style={{ fontSize: 12, fontFamily: 'monospace', color: 'rgba(255,255,255,0.7)', margin: 0 }}>
+                  {row.flag_key}
+                </p>
+                <p style={{ fontSize: 14, fontFamily: 'Oswald, sans-serif', fontWeight: 700, color: GOLD, margin: 0 }}>
+                  {row.exposures.toLocaleString()}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
No feature flag — core analytics infrastructure, always-on.

**New: `src/lib/analytics.ts`**
- `track(event_name, category?, label?, value?, properties?)` — fire-and-forget POST to /api/analytics/track
- `trackOnce(dedupeKey, ...)` — sends event only once per session (uses module-level Set)
- Uses `keepalive: true` so events survive page unload
- Errors swallowed — analytics never disrupts user flow

**New: `api/analytics/track.js`**
- POST /api/analytics/track — accepts anonymous + authenticated events
- Extracts user_id from Authorization JWT if present; anonymous events allowed
- Inserts to `analytics_events` via service role
- Returns 200 on error too — client should never retry analytics

**New: `src/pages/admin/FunnelPage.jsx` → `/admin/funnel`**
- Admin/superadmin only (redirects non-admins to /)
- Funnel table: age_gate_passed → signup → onboarding_stage_completed → profile_complete → first_message_sent → first_meet_committed → first_purchase
- Shows unique users + total events + % of top-of-funnel + step drop-off %
- Animated gold progress bar per step
- Flag exposures table: flag_key → exposure count (last 7/14/30d)
- Date range toggle: 7d / 14d / 30d

**Instrumented events:**
- `age_gate_passed` — AgeGateScreen.jsx on handleContinue ✅
- `signup` (label: provider) — SignUpScreen.jsx on OAuth + magic link success ✅
- `onboarding_stage_completed` (label: stage) — OnboardingRouter.jsx: quick_setup / profile_complete / pin_complete ✅
- `profile_complete` — OnboardingRouter.jsx on handlePinComplete ✅
- `flag_exposure` (properties: { flag_key }) — useV6Flag.js on first true resolution per session ✅
- `first_message_sent` / `first_meet_committed` / `first_purchase` — server-side instrumentation in API handlers (hnh_purchase already tracked in Chunk 16) ✅

**Updated: `src/App.jsx`**
- Added `/admin/funnel` route with lazy-loaded FunnelPage
