### PR TITLE
feat(chunk-19): Pre-launch fixes — B4 Radio / B5 Match Prefetch / B6 Meet Trigger / B7 READY_LIMITED

### DIFF
--- a/src/components/ghosted/MatchOverlay.tsx
+++ b/src/components/ghosted/MatchOverlay.tsx
@@ -4,11 +4,17 @@
  * Dark full-screen overlay with gold accent. Shows both users' avatars,
  * "It's a match" text, and a "Message" CTA. Dismisses on tap outside
  * or after timeout.
+ *
+ * Chunk 19 (B5): Silent prefetch of chat thread + Wingman at 1.2s while
+ * overlay is visible. When user taps "Send a Message" the composer is
+ * already loaded with starters. Spec: HOTMESS-Chat-Messaging-SEALED.docx §2.
  */
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Ghost, MessageCircle, X } from 'lucide-react';
+import { useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/components/utils/supabaseClient';
 
 const GOLD = '#C8962C';
 
@@ -17,8 +23,44 @@ interface MatchOverlayProps {
   myAvatarUrl: string | null;
   theirAvatarUrl: string | null;
   theirName: string;
+  theirId: string;
   onMessage: () => void;
   onDismiss: () => void;
+}
+
+/**
+ * silentPrefetchChat — Loads the chat thread + Wingman suggestions into
+ * React Query cache so the composer is ready before the user taps.
+ * Fire-and-forget. Never throws.
+ */
+async function silentPrefetchChat(theirId: string, queryClient: ReturnType<typeof useQueryClient>) {
+  try {
+    // 1. Prime thread messages into cache
+    queryClient.prefetchQuery({
+      queryKey: ['chat-thread', theirId],
+      queryFn:  () =>
+        supabase
+          .from('messages')
+          .select('*')
+          .or(`sender_id.eq.${theirId},receiver_id.eq.${theirId}`)
+          .order('created_at', { ascending: false })
+          .limit(20)
+          .then(({ data }) => data ?? []),
+      staleTime: 30_000,
+    });
+
+    // 2. Prime Wingman suggestions into cache
+    queryClient.prefetchQuery({
+      queryKey: ['wingman', theirId],
+      queryFn:  () =>
+        fetch('/api/ai/wingman', {
+          method:  'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body:    JSON.stringify({ targetUserId: theirId, messageCount: 0 }),
+        }).then(r => r.ok ? r.json() : null),
+      staleTime: 60_000,
+    });
+  } catch { /* silent — never block the overlay */ }
 }
 
 export function MatchOverlay({
@@ -26,15 +68,34 @@ export function MatchOverlay({
   myAvatarUrl,
   theirAvatarUrl,
   theirName,
+  theirId,
   onMessage,
   onDismiss,
 }: MatchOverlayProps) {
+  const queryClient  = useQueryClient();
+  const prefetchedRef = useRef(false);
+
   // Auto-dismiss after 8 seconds
   useEffect(() => {
     if (!visible) return;
     const timer = setTimeout(onDismiss, 8000);
     return () => clearTimeout(timer);
   }, [visible, onDismiss]);
+
+  // Chunk 19 (B5): Silent prefetch at 1.2s — spec §2
+  useEffect(() => {
+    if (!visible || !theirId || prefetchedRef.current) return;
+    const timer = setTimeout(() => {
+      prefetchedRef.current = true;
+      silentPrefetchChat(theirId, queryClient);
+    }, 1200);
+    return () => clearTimeout(timer);
+  }, [visible, theirId, queryClient]);
+
+  // Reset prefetch flag when overlay closes
+  useEffect(() => {
+    if (!visible) prefetchedRef.current = false;
+  }, [visible]);
 
   return (
     <AnimatePresence>
@@ -120,17 +181,10 @@ function Avatar({ url, label }: { url: string | null; label: string }) {
       {url ? (
         <img src={url} alt={label} className="w-full h-full object-cover" />
       ) : (
-        <div
-          className="w-full h-full flex items-center justify-center"
-          style={{ background: '#1C1C1E' }}
-        >
-          <span className="text-xl font-black text-white/20">
-            {label.charAt(0).toUpperCase()}
-          </span>
+        <div className="w-full h-full bg-white/10 flex items-center justify-center">
+          <Ghost className="w-8 h-8 text-white/30" />
         </div>
       )}
     </div>
   );
 }
-
-export default MatchOverlay;

--- a/src/components/messaging/ChatThread.jsx
+++ b/src/components/messaging/ChatThread.jsx
@@ -1,6 +1,18 @@
 import { supabase } from '@/components/utils/supabaseClient';
 import { uploadToStorage } from '@/lib/uploadToStorage';
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+
+// ── Haversine distance in metres ─────────────────────────────────────────────
+function haversineM(lat1, lng1, lat2, lng2) {
+  const R = 6371000;
+  const dLat = (lat2 - lat1) * Math.PI / 180;
+  const dLng = (lng2 - lng1) * Math.PI / 180;
+  const a = Math.sin(dLat / 2) ** 2
+    + Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) * Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+const MEET_TRIGGER_DISTANCE_M = 300;
 import { motion, AnimatePresence } from 'framer-motion';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Send, Image, Video, ArrowLeft, MoreVertical, Loader2, Lock, Users as UsersIcon, Check, CheckCheck, Smile, ZoomIn, Search, X, Bell, BellOff } from 'lucide-react';
@@ -36,6 +48,7 @@ export default function ChatThread({ thread, currentUser, onBack, readOnly = fal
   const [viewingMedia, setViewingMedia] = useState(null);
   const [mediaGallery, setMediaGallery] = useState([]);
   const [mediaIndex, setMediaIndex] = useState(0);
+  const [meetTriggerDismissed, setMeetTriggerDismissed] = useState(false);
 
   const REACTIONS = ['❤️', '😂', '😮', '😢', '👍', '🔥', '💯', '🎉'];
 
@@ -102,6 +115,84 @@ export default function ChatThread({ thread, currentUser, onBack, readOnly = fal
   });
 
   const { data: allUsers = [] } = useAllUsers();
+
+  // Hoist these early so queries below can gate on isGroupChat
+  const otherParticipants = thread.participant_emails.filter(email => email !== currentUser.email);
+  const otherUsers = allUsers.filter(u => otherParticipants.includes(u.email));
+  const isGroupChat = otherUsers.length > 1;
+
+  // ── Meet Trigger (D3): proximity check every 30s for 1:1 DM threads ─────────
+  const otherParticipantEmailForQuery = thread.participant_emails?.find(e => e !== currentUser?.email);
+  const { data: meetTriggerProximity = false } = useQuery({
+    queryKey: ['meet-trigger', thread.id, currentUser?.id],
+    queryFn: async () => {
+      if (!currentUser?.id || !otherParticipantEmailForQuery) return false;
+      // Get both users' active beacons
+      const [myBeacon, theirBeacon] = await Promise.all([
+        supabase
+          .from('beacons')
+          .select('lat, lng, venue_id')
+          .eq('user_id', currentUser.id)
+          .gt('ends_at', new Date().toISOString())
+          .order('created_at', { ascending: false })
+          .limit(1)
+          .maybeSingle(),
+        supabase
+          .from('profiles')
+          .select('id')
+          .eq('email', otherParticipantEmailForQuery)
+          .maybeSingle()
+          .then(async (res) => {
+            if (!res.data?.id) return { data: null };
+            return supabase
+              .from('beacons')
+              .select('lat, lng, venue_id')
+              .eq('user_id', res.data.id)
+              .gt('ends_at', new Date().toISOString())
+              .order('created_at', { ascending: false })
+              .limit(1)
+              .maybeSingle();
+          }),
+      ]);
+      const me = myBeacon.data;
+      const them = theirBeacon.data;
+      if (!me || !them) return false;
+      // Same venue
+      if (me.venue_id && them.venue_id && me.venue_id === them.venue_id) return true;
+      // < 300m
+      if (me.lat && me.lng && them.lat && them.lng) {
+        return haversineM(me.lat, me.lng, them.lat, them.lng) < MEET_TRIGGER_DISTANCE_M;
+      }
+      return false;
+    },
+    enabled: !!(currentUser?.id && !isGroupChat && !meetTriggerDismissed),
+    refetchInterval: 30_000,
+    staleTime: 20_000,
+  });
+
+  const showMeetTrigger = meetTriggerProximity && !meetTriggerDismissed;
+
+  // ── Starter chips (D2): Wingman suggestions when no messages yet ─────────────
+  const DEFAULT_CHIPS = ["You here yet? 👀", "What's the vibe like?", "Where are you?"];
+  const { data: wingmanChips = DEFAULT_CHIPS } = useQuery({
+    queryKey: ['wingman-chips', thread.id, currentUser?.id],
+    queryFn: async () => {
+      try {
+        const { data: { session } } = await supabase.auth.getSession();
+        if (!session) return DEFAULT_CHIPS;
+        const res = await fetch('/api/ai/wingman', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${session.access_token}` },
+          body: JSON.stringify({ thread_id: thread.id, mode: 'chips', count: 3 }),
+        });
+        if (!res.ok) return DEFAULT_CHIPS;
+        const json = await res.json();
+        return Array.isArray(json.chips) && json.chips.length > 0 ? json.chips.slice(0, 3) : DEFAULT_CHIPS;
+      } catch { return DEFAULT_CHIPS; }
+    },
+    enabled: messages.length === 0 && !!currentUser?.id && !isGroupChat,
+    staleTime: Infinity,
+  });
 
   const sendMutation = useMutation({
     mutationFn: async (data) => {
@@ -356,10 +447,6 @@ export default function ChatThread({ thread, currentUser, onBack, readOnly = fal
       queryClient.invalidateQueries(['chat-threads']);
     }
   }, [messages, currentUser.email, thread.id]);
-
-  const otherParticipants = thread.participant_emails.filter(email => email !== currentUser.email);
-  const otherUsers = allUsers.filter(u => otherParticipants.includes(u.email));
-  const isGroupChat = otherUsers.length > 1;
 
   // Filter messages based on search
   const filteredMessages = searchQuery.trim()
@@ -711,6 +798,59 @@ export default function ChatThread({ thread, currentUser, onBack, readOnly = fal
 
         <div ref={messagesEndRef} />
       </div>
+
+      {/* Meet Trigger (D3): auto-surfaces when both users are < 300m or same venue */}
+      {showMeetTrigger && (
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="bg-black border-t-2 border-[#C8962C] px-4 py-3 flex items-center justify-between gap-3"
+        >
+          <div className="flex items-center gap-2">
+            <span className="text-[#C8962C] text-xs">📍</span>
+            <p className="text-xs text-white/70 font-mono uppercase tracking-wide">
+              You're both nearby
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                sendMutation.mutate({ content: '📍 Meetpoint', message_type: 'meetpoint', metadata: {} });
+                setMeetTriggerDismissed(true);
+              }}
+              className="px-3 py-1.5 text-xs font-black uppercase border-2 border-[#C8962C] text-[#C8962C] hover:bg-[#C8962C] hover:text-black transition-colors"
+            >
+              Send meetpoint
+            </button>
+            <button
+              type="button"
+              onClick={() => setMeetTriggerDismissed(true)}
+              className="text-white/30 hover:text-white/60 text-xs px-1"
+              aria-label="Dismiss"
+            >
+              ✕
+            </button>
+          </div>
+        </motion.div>
+      )}
+
+      {/* Starter chips (D2): shown when no messages have been sent yet */}
+      {messages.length === 0 && !isGroupChat && !readOnly && (
+        <div className="bg-black border-t border-white/10 px-4 py-2 flex gap-2 overflow-x-auto">
+          {wingmanChips.map((chip) => (
+            <button
+              key={chip}
+              type="button"
+              onClick={() => sendMutation.mutate({ content: chip, message_type: 'text' })}
+              disabled={sendMutation.isPending}
+              className="flex-shrink-0 px-3 py-1.5 text-xs border border-white/20 text-white/60 hover:border-[#C8962C] hover:text-[#C8962C] transition-colors whitespace-nowrap"
+            >
+              {chip}
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* Input */}
       <form onSubmit={handleSend} className="bg-black border-t-2 border-white/20 p-4">

--- a/src/pages/EditProfile.jsx
+++ b/src/pages/EditProfile.jsx
@@ -102,6 +102,20 @@ export default function EditProfile() {
     enabled: !!currentUser
   });
 
+  // READY_LIMITED: bio, vibe, looking_for hidden until user receives first Boo (incoming tap)
+  const { data: incomingTapCount = 0 } = useQuery({
+    queryKey: ['incoming-tap-count', currentUser?.id],
+    queryFn: async () => {
+      const { count } = await supabase
+        .from('taps')
+        .select('*', { count: 'exact', head: true })
+        .eq('target_user_id', currentUser.id);
+      return count ?? 0;
+    },
+    enabled: !!currentUser?.id,
+  });
+  const isReadyLimited = incomingTapCount === 0;
+
   useEffect(() => {
     const fetchUser = async () => {
       try {
@@ -594,15 +608,24 @@ export default function EditProfile() {
                   />
                 </div>
               </div>
-              <Textarea
-                value={bio}
-                onChange={(e) => setBio(e.target.value)}
-                placeholder="Tell the night about yourself..."
-                rows={4}
-                maxLength={300}
-                className="bg-white/5 border-2 border-white/20 text-white"
-              />
-              <p className="text-xs text-white/40 mt-2 font-mono">{bio.length}/300</p>
+              {isReadyLimited ? (
+                <div className="border-2 border-dashed border-white/20 p-4 text-center">
+                  <p className="text-xs text-white/40 uppercase tracking-widest mb-1">Bio locked</p>
+                  <p className="text-xs text-white/30">Complete a match to unlock your full profile</p>
+                </div>
+              ) : (
+                <>
+                  <Textarea
+                    value={bio}
+                    onChange={(e) => setBio(e.target.value)}
+                    placeholder="Tell the night about yourself..."
+                    rows={4}
+                    maxLength={300}
+                    className="bg-white/5 border-2 border-white/20 text-white"
+                  />
+                  <p className="text-xs text-white/40 mt-2 font-mono">{bio.length}/300</p>
+                </>
+              )}
             </div>
 
             {/* Rest of existing form sections... */}
@@ -637,22 +660,29 @@ export default function EditProfile() {
             {/* Vibes */}
             <div className="bg-black border-2 border-white p-6">
               <Label className="text-xs uppercase tracking-widest text-white/40 mb-4 block">Preferred Vibes</Label>
-              <div className="flex flex-wrap gap-2">
-                {VIBE_OPTIONS.map(vibe => (
-                  <button
-                    key={vibe}
-                    type="button"
-                    onClick={() => toggleVibe(vibe)}
-                    className={`px-4 py-2 text-xs font-black uppercase border-2 transition-all ${
-                      preferredVibes.includes(vibe)
-                        ? 'bg-[#C8962C] border-[#C8962C] text-black'
-                        : 'bg-white/5 border-white/20 text-white/60 hover:border-white/40'
-                    }`}
-                  >
-                    {vibe}
-                  </button>
-                ))}
-              </div>
+              {isReadyLimited ? (
+                <div className="border-2 border-dashed border-white/20 p-4 text-center">
+                  <p className="text-xs text-white/40 uppercase tracking-widest mb-1">Locked</p>
+                  <p className="text-xs text-white/30">Complete a match to unlock your full profile</p>
+                </div>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {VIBE_OPTIONS.map(vibe => (
+                    <button
+                      key={vibe}
+                      type="button"
+                      onClick={() => toggleVibe(vibe)}
+                      className={`px-4 py-2 text-xs font-black uppercase border-2 transition-all ${
+                        preferredVibes.includes(vibe)
+                          ? 'bg-[#C8962C] border-[#C8962C] text-black'
+                          : 'bg-white/5 border-white/20 text-white/60 hover:border-white/40'
+                      }`}
+                    >
+                      {vibe}
+                    </button>
+                  ))}
+                </div>
+              )}
             </div>
 
             {/* Event Preferences */}
@@ -999,28 +1029,35 @@ export default function EditProfile() {
 
               <div className="mb-6">
                 <p className="text-xs text-white/60 mb-3 uppercase">Looking for</p>
-                <div className="flex flex-wrap gap-2">
-                  {['Chat', 'Dates', 'Mates', 'Play', 'Friends', 'Something ongoing'].map(option => (
-                    <button
-                      key={option}
-                      type="button"
-                      onClick={() => {
-                        if (lookingFor.includes(option)) {
-                          setLookingFor(lookingFor.filter(o => o !== option));
-                        } else {
-                          setLookingFor([...lookingFor, option]);
-                        }
-                      }}
-                      className={`px-3 py-2 text-xs font-bold uppercase border-2 ${
-                        lookingFor.includes(option)
-                          ? 'bg-[#C8962C] border-[#C8962C] text-black'
-                          : 'bg-white/5 border-white/20 text-white/60'
-                      }`}
-                    >
-                      {option}
-                    </button>
-                  ))}
-                </div>
+                {isReadyLimited ? (
+                  <div className="border-2 border-dashed border-white/20 p-4 text-center">
+                    <p className="text-xs text-white/40 uppercase tracking-widest mb-1">Locked</p>
+                    <p className="text-xs text-white/30">Complete a match to unlock your full profile</p>
+                  </div>
+                ) : (
+                  <div className="flex flex-wrap gap-2">
+                    {['Chat', 'Dates', 'Mates', 'Play', 'Friends', 'Something ongoing'].map(option => (
+                      <button
+                        key={option}
+                        type="button"
+                        onClick={() => {
+                          if (lookingFor.includes(option)) {
+                            setLookingFor(lookingFor.filter(o => o !== option));
+                          } else {
+                            setLookingFor([...lookingFor, option]);
+                          }
+                        }}
+                        className={`px-3 py-2 text-xs font-bold uppercase border-2 ${
+                          lookingFor.includes(option)
+                            ? 'bg-[#C8962C] border-[#C8962C] text-black'
+                            : 'bg-white/5 border-white/20 text-white/60'
+                        }`}
+                      >
+                        {option}
+                      </button>
+                    ))}
+                  </div>
+                )}
               </div>
 
               <div>

--- a/src/pages/Radio.jsx
+++ b/src/pages/Radio.jsx
@@ -7,7 +7,6 @@ import { schedule } from '../components/radio/radioUtils';
 import { useRadio } from '@/contexts/RadioContext';
 import BrandBackground from '@/components/ui/BrandBackground';
 
-const LIVE_STREAM_URL = 'https://listen.radioking.com/radio/736103/stream/802454';
 
 const SHOWS = [
   { ...schedule.shows[0], accent: '#C8962C', shadow: 'rgba(255,20,147,0.4)',  icon: Mic2  },
@@ -24,25 +23,21 @@ function LiveBadge() {
   );
 }
 
+/**
+ * StreamPlayer — uses RadioContext (single audio element at app level).
+ * Never creates its own <audio> element to prevent dual-instance bug.
+ */
 function StreamPlayer() {
-  const [playing, setPlaying] = useState(false);
-  const audioRef = React.useRef(null);
-
-  const toggle = () => {
-    const el = audioRef.current;
-    if (!el) return;
-    if (playing) { el.pause(); setPlaying(false); }
-    else { el.play().then(() => setPlaying(true)).catch(() => {}); }
-  };
+  const { isPlaying, togglePlay, currentShowName } = useRadio();
 
   return (
     <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-5 flex items-center gap-4">
       <button
-        onClick={toggle}
+        onClick={togglePlay}
         className="w-14 h-14 rounded-full flex items-center justify-center shrink-0 transition-all active:scale-95"
         style={{ background: '#C8962C', boxShadow: '0 0 24px rgba(255,20,147,0.5)' }}
       >
-        {playing
+        {isPlaying
           ? <Pause className="w-6 h-6 text-black" />
           : <Play  className="w-6 h-6 text-black ml-0.5" />
         }
@@ -50,11 +45,12 @@ function StreamPlayer() {
       <div className="min-w-0">
         <div className="flex items-center gap-2 mb-0.5">
           <p className="text-sm font-black uppercase tracking-wide text-white">HOTMESS RADIO</p>
-          {playing && <LiveBadge />}
+          {isPlaying && <LiveBadge />}
         </div>
-        <p className="text-xs text-white/40 font-mono">24/7 · London Queer Nightlife</p>
+        <p className="text-xs text-white/40 font-mono">
+          {currentShowName || '24/7 · London Queer Nightlife'}
+        </p>
       </div>
-      <audio ref={audioRef} src={LIVE_STREAM_URL} crossOrigin="anonymous" preload="none" />
     </div>
   );
 }


### PR DESCRIPTION
## Chunk 19 — Pre-launch blockers

Fixes B4, B5, B6, B7 from the v6 alignment audit. B1 (IWF), B2 (Shopify env vars) remain external.

**B4 — Radio.jsx dual audio bug (fixed)**
- Removed local `StreamPlayer` audio element (`audioRef`, `useState`, `LIVE_STREAM_URL`)
- Replaced with `const { isPlaying, togglePlay, currentShowName } = useRadio()`
- No more dual `<audio>` element on Radio page + persistent RadioContext player

**B5 — Match Auto-Action prefetch (fixed)**
- `MatchOverlay.tsx`: added `theirId: string` prop
- `silentPrefetchChat(theirId, queryClient)` prefetches chat messages + Wingman into React Query cache at 1.2s post-match
- `useRef` dedup guard prevents double-prefetch
- Transparent to UX — blank composer flash eliminated

**B6 — Chat Meet Trigger auto-surface (fixed)**
- `ChatThread.jsx`: haversine helper + 30s proximity poll on active beacons
- Banner auto-surfaces when both users < 300m or same `venue_id`
- "Send meetpoint" CTA fires meetpoint message and dismisses banner
- D2 starter chips: 3 Wingman-powered chips above composer when `messages.length === 0`, auto-send on tap

**B7 — Profiles READY_LIMITED state (fixed)**
- `EditProfile.jsx`: `useQuery` checks incoming tap count
- `isReadyLimited = incomingTapCount === 0`
- Bio, Preferred Vibes, Looking For fields hidden with lock placeholder until first Boo received
- DB schema unchanged