### PR TITLE
chore(typecheck): clear 27 pre-existing TS errors across 9 files

### DIFF
--- a/src/components/sheets/L2GhostedPreviewSheet.tsx
+++ b/src/components/sheets/L2GhostedPreviewSheet.tsx
@@ -391,6 +391,7 @@ export default function L2GhostedPreviewSheet({ uid }: { uid?: string }) {
         myAvatarUrl={myAvatarUrl}
         theirAvatarUrl={heroUrl}
         theirName={profile.display_name || 'Someone'}
+        theirId={profile.id}
         onMessage={handleMatchMessage}
         onDismiss={() => setShowMatch(false)}
       />

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -1,21 +1,37 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, type RefObject } from 'react';
 import { toast } from 'sonner';
 
+const THRESHOLD = 120; // pixels to pull before refresh
+
+interface UsePullToRefreshOptions {
+  disabled?: boolean;
+  /** If provided, runs instead of `window.location.reload()` on refresh trigger. */
+  onRefresh?: () => void | Promise<void>;
+  /** Currently informational — surfaced for caller compat with the gesture-on-element pattern. */
+  scrollRef?: RefObject<HTMLElement | null>;
+}
+
 /**
- * usePullToRefresh — Global gesture for site reload
- * 
- * Detects downward swipe from top. Shows progress. Reloads window.
+ * usePullToRefresh — Global gesture for site reload (or custom refresh callback).
+ *
+ * Detects downward swipe from top. Shows progress. Triggers `onRefresh()` if
+ * given, else reloads the window.
+ *
+ * Returns { pullProgress (0-1), pullDistance (px), isRefreshing, handlers }.
+ * `handlers` is currently a no-op spread for caller-side compat (`{...handlers}`
+ * on a div). The hook attaches its listeners to window, not the element.
  */
-export function usePullToRefresh(options: { disabled?: boolean } = {}) {
-  const { disabled = false } = options;
+export function usePullToRefresh(options: UsePullToRefreshOptions = {}) {
+  const { disabled = false, onRefresh } = options;
   const [pullProgress, setPullProgress] = useState(0); // 0 to 1
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const onRefreshRef = useRef(onRefresh);
+  onRefreshRef.current = onRefresh;
 
   
   const startY = useRef(0);
   const currentY = useRef(0);
   const isPulling = useRef(false);
-  const THRESHOLD = 120; // pixels to pull before refresh
 
   useEffect(() => {
     const handleTouchStart = (e: TouchEvent) => {
@@ -76,16 +92,23 @@ export function usePullToRefresh(options: { disabled?: boolean } = {}) {
       if (diff >= THRESHOLD) {
         setIsRefreshing(true);
         setPullProgress(1);
-        
-        // Final gold toast + reload
-        toast.loading('Refreshing HOTMESS...', { 
-          duration: 2000,
-          style: { background: '#000', color: '#C8962C', border: '1px solid #C8962C' }
-        });
-        
-        setTimeout(() => {
-          window.location.reload();
-        }, 800);
+
+        if (onRefreshRef.current) {
+          // Caller-supplied refresh — invalidate queries / re-fetch / etc.
+          Promise.resolve(onRefreshRef.current())
+            .catch(() => { /* swallow — caller logs */ })
+            .finally(() => {
+              setIsRefreshing(false);
+              setPullProgress(0);
+            });
+        } else {
+          // Default: full window reload with a gold toast.
+          toast.loading('Refreshing HOTMESS...', {
+            duration: 2000,
+            style: { background: '#000', color: '#C8962C', border: '1px solid #C8962C' },
+          });
+          setTimeout(() => { window.location.reload(); }, 800);
+        }
       } else {
         setPullProgress(0);
       }
@@ -105,5 +128,10 @@ export function usePullToRefresh(options: { disabled?: boolean } = {}) {
   }, [isRefreshing, disabled]);
 
 
-  return { pullProgress, isRefreshing };
+  return {
+    pullProgress,
+    pullDistance: pullProgress * THRESHOLD,
+    isRefreshing,
+    handlers: {} as Record<string, never>,
+  };
 }

--- a/src/lib/ai/index.ts
+++ b/src/lib/ai/index.ts
@@ -106,7 +106,7 @@ export async function callWingman(
   context: WingmanContext,
   opts?: AICallOptions
 ): Promise<AICallResult<WingmanResult>> {
-  return callAI<WingmanResult>('wingman', context as Record<string, unknown>, opts);
+  return callAI<WingmanResult>('wingman', context as unknown as Record<string, unknown>, opts);
 }
 
 // ──
@@ -129,7 +129,7 @@ export async function callSceneScout(
   context: SceneScoutContext,
   opts?: AICallOptions
 ): Promise<AICallResult<SceneScoutResult>> {
-  return callAI<SceneScoutResult>('scene-scout', context as Record<string, unknown>, opts);
+  return callAI<SceneScoutResult>('scene-scout', context as unknown as Record<string, unknown>, opts);
 }
 
 // ──
@@ -150,7 +150,7 @@ export async function callChat(
   context: ChatContext,
   opts?: AICallOptions
 ): Promise<AICallResult<ChatResult>> {
-  return callAI<ChatResult>('chat', context as Record<string, unknown>, opts);
+  return callAI<ChatResult>('chat', context as unknown as Record<string, unknown>, opts);
 }
 
 // ──
@@ -163,5 +163,5 @@ export async function callProfileAnalysis(
   context: ProfileAnalysisContext,
   opts?: AICallOptions
 ): Promise<AICallResult<Record<string, unknown>>> {
-  return callAI('profile-analysis', context as Record<string, unknown>, opts);
+  return callAI('profile-analysis', context as unknown as Record<string, unknown>, opts);
 }

--- a/src/lib/native.ts
+++ b/src/lib/native.ts
@@ -9,7 +9,7 @@
  */
 
 // Lazy-import Capacitor so the bundle does not break in non-Capacitor builds
-const isNative = (): boolean => {
+export const isNative = (): boolean => {
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { Capacitor } = window as any;

--- a/src/lib/proximity/failureSystem.ts
+++ b/src/lib/proximity/failureSystem.ts
@@ -144,7 +144,7 @@ function deriveState(
   return 'minimal';
 }
 
-function buildStateObject(
+export function buildStateObject(
   state:      SignalState,
   distM:      number | null,
   headerOverride?: string,

--- a/src/lib/purchases.ts
+++ b/src/lib/purchases.ts
@@ -149,9 +149,11 @@ export async function purchaseBoost(
     const { Purchases } = await import('@revenuecat/purchases-capacitor');
     const { offerings } = await Purchases.getOfferings();
 
-    // Find the boost product across all offerings
+    // Find the boost product across all offerings.
+    // RevenueCat module is `any` via shim — cast the per-offering value so
+    // .availablePackages is reachable without losing the rest of the type.
     const allPackages = Object.values(offerings?.all ?? {}).flatMap(
-      (o) => o.availablePackages
+      (o: { availablePackages?: Array<{ product: { identifier: string } }> }) => o.availablePackages ?? []
     );
     const pkg = allPackages.find((p) => p.product.identifier === productId);
     if (!pkg) return { success: false, error: `Boost product "${productId}" not in offerings` };

--- a/src/modes/HomeMode.tsx
+++ b/src/modes/HomeMode.tsx
@@ -61,7 +61,7 @@ export default function HomeMode({ className = '' }: HomeModeProps) {
   const navigate = useNavigate();
   const { openSheet } = useSheet();
   const { profile } = useBootGuard();
-  const { isPlaying: radioPlaying, activeUrl, togglePlay, setCurrentShowName, currentShowName } = useRadio();
+  const { isPlaying: radioPlaying, togglePlay, setCurrentShowName, currentShowName } = useRadio();
   const reduced = useReducedMotion();
 
   const [showRightNow, setShowRightNow] = useState(false);

--- a/src/pages/MorePage.tsx
+++ b/src/pages/MorePage.tsx
@@ -22,7 +22,7 @@ import { useQueryClient, useQuery } from '@tanstack/react-query';
 import { supabase } from '@/components/utils/supabaseClient';
 
 import { useSheet } from '@/contexts/SheetContext';
-import { RadioProvider, useRadio, STREAM_URL_BASE } from '@/contexts/RadioContext';
+import { RadioProvider, useRadio } from '@/contexts/RadioContext';
 import { RadioMiniPlayer } from '@/components/radio/RadioMiniPlayer';
 import { Radio as RadioIcon } from 'lucide-react';
 

--- a/src/test/sosContext.test.tsx
+++ b/src/test/sosContext.test.tsx
@@ -19,7 +19,7 @@ function SOSConsumer() {
   return (
     <div>
       <span data-testid="sos-status">{sosActive ? 'active' : 'inactive'}</span>
-      <button onClick={triggerSOS} data-testid="trigger">Trigger SOS</button>
+      <button onClick={() => { void triggerSOS(); }} data-testid="trigger">Trigger SOS</button>
       <button onClick={clearSOS} data-testid="clear">Clear SOS</button>
     </div>
   );

--- a/src/types/capacitor-shims.d.ts
+++ b/src/types/capacitor-shims.d.ts
@@ -1,0 +1,23 @@
+/**
+ * Module shims for native-only Capacitor packages.
+ *
+ * These are dynamically imported inside try/catch in src/lib/native.ts and
+ * src/lib/purchases.ts; they only resolve at runtime on iOS/Android Capacitor
+ * builds. The packages are NOT installed in the web/Vercel build, so without
+ * shims TypeScript fails the typecheck step.
+ *
+ * Typing them as `any` matches how native.ts already uses them (every call is
+ * wrapped in try/catch with a web fallback) and keeps the web bundle slim.
+ *
+ * If proper types are wanted in the future, install the matching packages as
+ * devDependencies and delete this file.
+ */
+
+declare module '@capacitor/haptics';
+declare module '@capacitor/push-notifications';
+declare module '@capacitor/geolocation';
+declare module '@capacitor/camera';
+declare module '@capacitor/share';
+declare module '@capacitor/status-bar';
+declare module '@capacitor/app';
+declare module '@revenuecat/purchases-capacitor';


### PR DESCRIPTION
## Why

Third sequential cleanup PR. Per Phil's split decision in #216 / #217 — small, focused, reviewable in two minutes. Brings `Lint → Typecheck → Build` CI check fully green after the merge train (#217 → round 2 amend → #216 → this).

Clears all 27 pre-existing TypeScript errors on `main`. Behavioural changes are limited to two surface areas where types had drifted from real usage — both fixes restore intended behaviour, not invent new features.

## Merge order

1. ✅ `chore/main-cleanup` (#217) — postcss/protobuf bumps, eslint --fix, SOSButton.jsx removal
2. ✅ Round 2 amend (`claude/v6-verification-round2-fswa4`)
3. ✅ Round 3 (#216) — multi-channel safety dispatcher
4. ✅ **This PR** — typecheck cleanup

After all four: `lint=0`, `typecheck=0`, `build=green`, `audit=0 vulns`. Dispatcher infrastructure built and dormant, ready for round 4 to wire Care surfaces.

## What changed

### `src/types/capacitor-shims.d.ts` (new)
Module shims for `@capacitor/{haptics,push-notifications,geolocation,camera,share,status-bar,app}` + `@revenuecat/purchases-capacitor`. These are dynamically imported inside `try/catch` in `native.ts` + `purchases.ts` and only resolve at runtime on iOS/Android Capacitor builds. The web/Vercel build doesn't install them, so without shims TypeScript fails the typecheck step. Typed as `any` because every call is wrapped in try/catch with a web fallback.

### `src/lib/native.ts`
`isNative` was a module-local `const` but `purchases.ts` imports it. Exported it.

### `src/lib/purchases.ts`
Cast offering value in `Object.values(...).flatMap(...)` so `.availablePackages` is reachable. RevenueCat module is `any` via shim so the cast preserves the rest of the per-offering type info.

### `src/lib/proximity/failureSystem.ts`
Exported `buildStateObject` (used by `useProximityFailure.ts`).

### `src/lib/ai/index.ts`
Three `callAI()` calls had `context as Record<string, unknown>` — TS rejects with TS2352 because `WingmanContext`/`ChatContext`/`ProfileAnalysisContext` don't sufficiently overlap with `Record`. Per the TS suggestion: `as unknown as Record<string, unknown>`.

### `src/modes/HomeMode.tsx`
Dropped unused `activeUrl` from `useRadio()` destructure — not on `RadioContextValue`, never referenced anywhere in the file.

### `src/pages/MorePage.tsx`
Dropped unused `STREAM_URL_BASE` import from `RadioContext` — not exported, not referenced.

### `src/hooks/usePullToRefresh.ts`
Real surface drift between hook (`{ pullProgress, isRefreshing }` accepting `{ disabled }`) and 2 callers (`RadioMode.tsx` + `MusicTab.jsx`) which both want `{ pullDistance, isRefreshing, handlers }` from `{ onRefresh, scrollRef }`. Extended the hook to accept `onRefresh`/`scrollRef` and return `pullDistance` (= `pullProgress * THRESHOLD`) + `handlers` (no-op for now — gesture is window-level). When `onRefresh` is provided it runs instead of the hardcoded `window.location.reload()`. Both callers now actually work at runtime, not just typecheck.

### `src/components/sheets/L2GhostedPreviewSheet.tsx`
Pass missing `theirId={profile.id}` prop to `MatchOverlay` (was required by `MatchOverlayProps` but not provided).

### `src/test/sosContext.test.tsx`
`triggerSOS` has signature `(opts?: { silent?: boolean }) => Promise<void>` — incompatible with React's `MouseEventHandler<HTMLButtonElement>`. Wrapped: `() => { void triggerSOS(); }`.

## Quality gate

| Check | Before | After |
|---|---|---|
| `npm run typecheck` | exit 2, **27 errors** | exit 0, **0 errors** ✅ |
| `npm run build` | green | green ✅ |
| Tests | 6 pre-existing failures | 6 pre-existing failures (verified by stashing my changes; same 6 fail on baseline — not from this PR) |

## What's NOT in this PR (intentional)

- **`package-lock.json`** — `npm install` resolved the missing `@anthropic-ai/sdk` lockfile entry. Reverted because that fix lives in #217 and overlaps would create merge conflict.
- **The 6 pre-existing test failures** in `supportProximity.test.js`, `badgeMath.test.ts`, `bootGuard.test.tsx`, `ecommerce.test.ts`. Out of scope — separate cleanup if they're worth fixing.
- **The 46 pre-existing lint errors** — already covered by #217.

https://claude.ai/code/session_01D6bErwydxi8xbnC7dRsM7Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6bErwydxi8xbnC7dRsM7Z)_