### PR TITLE
[MEGA-3 PR-A] safety_alerts dispatcher columns (unblocks MEGA-2)

### DIFF
--- a/supabase/migrations/20260507000001_safety_alerts_dispatcher_columns.sql
+++ b/supabase/migrations/20260507000001_safety_alerts_dispatcher_columns.sql
@@ -1,0 +1,29 @@
+-- MEGA-3 PR-A: enable MEGA-2 panic-alert dispatcher to insert per-contact rows
+-- on public.safety_alerts. Additive only. Existing event-level usage preserved.
+
+ALTER TABLE public.safety_alerts
+  ADD COLUMN IF NOT EXISTS contact_id uuid REFERENCES public.trusted_contacts(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS channel text,
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'queued',
+  ADD COLUMN IF NOT EXISTS payload jsonb,
+  ADD COLUMN IF NOT EXISTS delivered_at timestamptz,
+  ADD COLUMN IF NOT EXISTS error_message text;
+
+ALTER TABLE public.safety_alerts ALTER COLUMN alert_type DROP NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_safety_alerts_status_created
+  ON public.safety_alerts (status, created_at)
+  WHERE status IN ('queued', 'failed');
+
+CREATE INDEX IF NOT EXISTS idx_safety_alerts_contact_id
+  ON public.safety_alerts (contact_id) WHERE contact_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_safety_alerts_user_status
+  ON public.safety_alerts (user_id, status, created_at DESC);
+
+COMMENT ON COLUMN public.safety_alerts.contact_id IS
+  'Per-recipient row when dispatched via panic-alert; null for event-level rows';
+COMMENT ON COLUMN public.safety_alerts.channel IS
+  'Delivery channel: sms | whatsapp | telegram | email | push';
+COMMENT ON COLUMN public.safety_alerts.status IS
+  'queued | dispatched | delivered | failed';


### PR DESCRIPTION
## Summary

Adds the per-contact dispatcher columns the MEGA-2 panic-alert rewrite needs on `public.safety_alerts`: `contact_id`, `channel`, `status` (default `'queued'`), `payload`, `delivered_at`, `error_message`. Indexes for queue scan and per-user lookup. `alert_type` relaxed to nullable so per-channel rows can insert without it (existing rows: 0).

Additive only — applied to production via `apply_migration`. Existing event-level usage preserved.

## Why first

MEGA-2 §2.2 (panic-alert) is gated on this schema landing.

## Test plan

- [x] Migration applied to prod (`rfoftonnlwudilafhfkl`)
- [x] Schema verified: 6 new columns present, `alert_type` nullable, 3 new indexes created
- [ ] MEGA-2 dispatcher rewrite to insert per-contact rows (separate PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced safety alert system infrastructure to support per-contact message dispatching with improved delivery tracking and status monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->