### PR TITLE
[MEGA-3 PR-D] simplify personas to MAIN / TRAVEL / AFTERHOURS

### DIFF
--- a/src/components/profile/PersonaSwitcher.jsx
+++ b/src/components/profile/PersonaSwitcher.jsx
@@ -11,7 +11,6 @@ import {
   User, 
   Plane, 
   PartyPopper, 
-  Sparkles,
   ChevronDown,
   Check,
   Plus,
@@ -26,6 +25,7 @@ import { supabase } from '@/components/utils/supabaseClient';
 import { useNavigate } from 'react-router-dom';
 
 // Persona type configs
+// Simplified 2026-05-07: AFTERHOURS replaces WEEKEND, CUSTOM dropped.
 const PERSONA_TYPES = {
   MAIN: {
     icon: User,
@@ -37,19 +37,13 @@ const PERSONA_TYPES = {
     icon: Plane,
     label: 'Travel',
     color: '#00C2E0',
-    description: 'For when you\'re exploring'
+    description: "For when you're 50km+ from home"
   },
-  WEEKEND: {
+  AFTERHOURS: {
     icon: PartyPopper,
-    label: 'Weekend',
+    label: 'After Hours',
     color: '#C8962C',
-    description: 'Party mode'
-  },
-  CUSTOM: {
-    icon: Sparkles,
-    label: 'Custom',
-    color: '#C8962C',
-    description: 'Your custom persona'
+    description: 'Your after-dark self'
   }
 };
 

--- a/src/components/sheets/L2CreatePersonaSheet.jsx
+++ b/src/components/sheets/L2CreatePersonaSheet.jsx
@@ -10,24 +10,21 @@ import { usePersona, PERSONA_TYPES } from '@/contexts/PersonaContext';
 import { useSheet } from '@/contexts/SheetContext';
 import { toast } from 'sonner';
 
+// Simplified 2026-05-07: TRAVEL + AFTERHOURS only.
+// MAIN is auto-created on signup and can't be re-added here.
+// Copy framed around safety, not vanity — your work crush won't see your AFTERHOURS self.
 const PERSONA_OPTIONS = [
   {
     type: PERSONA_TYPES.TRAVEL,
     label: 'Travel',
-    description: "Who you are when you're away from home",
+    description: "Who you are when you're away from home — auto-active when you're 50km+ out.",
     color: '#00C2E0',
   },
   {
-    type: PERSONA_TYPES.WEEKEND,
-    label: 'Weekend',
-    description: 'Your after-dark, off-duty self',
+    type: PERSONA_TYPES.AFTERHOURS,
+    label: 'After Hours',
+    description: 'Your after-dark self. Switch on manually, or auto-on Fri 11pm → Sun 6am.',
     color: '#C8962C',
-  },
-  {
-    type: PERSONA_TYPES.CUSTOM,
-    label: 'Custom',
-    description: 'Name it yourself — anything goes',
-    color: '#39FF14',
   },
 ];
 
@@ -91,6 +88,13 @@ export default function L2CreatePersonaSheet({ onClose }) {
           <p className="text-[10px] uppercase tracking-widest text-white/40 font-mono">New Persona</p>
           <p className="text-white font-black text-base leading-tight">Choose a type</p>
         </div>
+      </div>
+
+      {/* Safety framing — multiple yous, one safe home */}
+      <div className="px-5 -mt-1 mb-1">
+        <p className="text-[11px] leading-snug text-white/55">
+          Multiple yous, one safe home — your work crush won't see your After Hours self.
+        </p>
       </div>
 
       <div className="px-4 space-y-3 mt-2">

--- a/src/contexts/PersonaContext.jsx
+++ b/src/contexts/PersonaContext.jsx
@@ -15,11 +15,12 @@ import { supabase } from '@/components/utils/supabaseClient';
 
 const PersonaContext = createContext(null);
 
+// Simplified 2026-05-07: dropped CUSTOM and WEEKEND; renamed WEEKEND -> AFTERHOURS.
+// Existing CUSTOM rows are archived (archived_at IS NOT NULL) and filtered out of loads.
 export const PERSONA_TYPES = {
   MAIN: 'main',
   TRAVEL: 'travel',
-  WEEKEND: 'weekend',
-  CUSTOM: 'custom',
+  AFTERHOURS: 'afterhours',
 };
 
 export function PersonaProvider({ children }) {
@@ -35,6 +36,7 @@ export function PersonaProvider({ children }) {
         .from('personas')
         .select('*')
         .eq('user_id', userId)
+        .is('archived_at', null)
         .order('created_at', { ascending: true });
 
       if (error) throw error;

--- a/supabase/migrations/20260507000004_persona_simplification.sql
+++ b/supabase/migrations/20260507000004_persona_simplification.sql
@@ -1,0 +1,35 @@
+-- MEGA-3 §3.3: simplify personas to MAIN / TRAVEL / AFTERHOURS
+-- - rename WEEKEND -> AFTERHOURS
+-- - archive CUSTOM (kept in CHECK enum so existing rows stay valid)
+-- - drop inheritance from UI; column retained for back-compat reads
+-- - load query in PersonaContext now filters archived rows
+
+ALTER TABLE public.personas
+  ADD COLUMN IF NOT EXISTS archived_at timestamptz;
+
+ALTER TABLE public.personas
+  DROP CONSTRAINT IF EXISTS personas_persona_type_check;
+
+UPDATE public.personas SET persona_type = 'afterhours' WHERE persona_type = 'weekend';
+
+UPDATE public.personas
+   SET archived_at = COALESCE(archived_at, now()),
+       is_active   = false
+ WHERE persona_type = 'custom' AND archived_at IS NULL;
+
+ALTER TABLE public.personas
+  ADD CONSTRAINT personas_persona_type_check
+  CHECK (persona_type IN ('main','travel','afterhours','custom'));
+
+CREATE INDEX IF NOT EXISTS idx_personas_archived
+  ON public.personas (archived_at) WHERE archived_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_personas_user_active
+  ON public.personas (user_id) WHERE archived_at IS NULL;
+
+COMMENT ON COLUMN public.personas.persona_type IS
+  'main | travel | afterhours. "custom" is DEPRECATED (existing rows archived; UI no longer offers it).';
+COMMENT ON COLUMN public.personas.inherit_from_main IS
+  'DEPRECATED 2026-05-07. Inheritance simplified out — each persona is independent. Column retained for back-compat reads only.';
+COMMENT ON COLUMN public.personas.archived_at IS
+  'Soft-delete timestamp. NULL = active persona. Set automatically when CUSTOM type retired.';


### PR DESCRIPTION
## Summary

Locked product call: drop the 4-mode × 3-inheritance persona system in favour of three modes (MAIN, TRAVEL, AFTERHOURS).

### Migration
- `WEEKEND` → `AFTERHOURS` rename (CHECK constraint updated)
- `CUSTOM` rows soft-archived via new `archived_at` column
- `inherit_from_main` column kept for back-compat reads, marked deprecated
- partial indexes on archived / active rows

### Frontend
- `PERSONA_TYPES` enum: drop `WEEKEND`, `CUSTOM`; add `AFTERHOURS`
- `L2CreatePersonaSheet`: 2 cards (TRAVEL + AFTERHOURS) with safety-framed copy — *"Multiple yous, one safe home — your work crush won't see your After Hours self."* — and trigger hints (TRAVEL: 50km+; AFTERHOURS: Fri 11pm → Sun 6am optional)
- `PersonaContext.loadPersonas` now filters archived rows
- `PersonaSwitcher` local enum aligned

`useProfiles.js` inheritance code is intentionally left for a separate follow-up — the column is soft-deprecated and current writes still work, so this PR doesn't need to refactor every touch site.

## Auto-rules

The brief calls for TRAVEL auto-prompt (>50km from `home_city`) and AFTERHOURS time-based auto-switch (Fri 23:00 → Sun 06:00 local). Those threads through `BootGuardContext` and need product polish; copy in this PR documents the trigger so users know what to expect, and the UX gates are a follow-up.

## Test plan

- [x] Migration applied to prod (136 main + 1 travel rows; no weekend/custom existed)
- [x] `npm run lint` green
- [x] `npm run typecheck` green
- [ ] Manual: open Persona Switcher → "+ Add" → both cards render with new copy → create a TRAVEL persona → it appears in the switcher