### PR TITLE
[MEGA-3 PR-E] verification submission queue + /admin/verification

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -82,6 +82,7 @@ const ModerationPage = lazy(() => import('@/pages/admin/ModerationPage'));
 const FlagsAdmin    = lazy(() => import('@/pages/admin/FlagsAdmin'));
 const FunnelPage    = lazy(() => import('@/pages/admin/FunnelPage'));
 const RevenueDashboard = lazy(() => import('@/pages/admin/RevenueDashboard'));
+const VerificationQueue = lazy(() => import('@/pages/admin/VerificationQueue'));
 const SOSPage = lazy(() => import('@/pages/SOSPage'));
 const FakeCallPage = lazy(() => import('@/pages/FakeCallPage'));
 const SafetyPage = lazy(() => import('@/pages/Safety'));
@@ -502,6 +503,8 @@ const AuthenticatedApp = () => {
       <Route path="/admin/funnel" element={<Suspense fallback={<PageLoadingSkeleton type="feed" />}><FunnelPage /></Suspense>} />
       {/* ADMIN — D3 Revenue Dashboard */}
       <Route path="/admin/revenue" element={<Suspense fallback={<PageLoadingSkeleton type="feed" />}><RevenueDashboard /></Suspense>} />
+      {/* ADMIN — selfie verification queue (MEGA-3 §3.4) */}
+      <Route path="/admin/verification" element={<Suspense fallback={<PageLoadingSkeleton type="feed" />}><VerificationQueue /></Suspense>} />
       <Route path="*" element={<PageNotFound />} />
       </Routes>
     </PageTransition>

--- a/src/components/admin/UserVerification.jsx
+++ b/src/components/admin/UserVerification.jsx
@@ -1,143 +1,270 @@
-import { supabase } from '@/components/utils/supabaseClient';
-import React from 'react';
+/**
+ * Admin verification queue.
+ *
+ * Backed by public.profile_verifications:
+ *   pending   -> awaiting admin review (this queue)
+ *   approved  -> profiles.is_verified flipped true on approval
+ *   rejected  -> rejection_reason shown to user, can resubmit
+ *
+ * RLS lets only admins SELECT all + UPDATE here (see migration
+ * 20260507000005_verification_flow).
+ */
+
+import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { motion } from 'framer-motion';
 import { Badge, CheckCircle, XCircle, Clock, User } from 'lucide-react';
+import { supabase } from '@/components/utils/supabaseClient';
 import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
-import { motion } from 'framer-motion';
+
+const PAGE_SIZE = 50;
+
+function timeAgo(iso) {
+  if (!iso) return '';
+  const ms = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(ms / 60000);
+  if (m < 1) return 'just now';
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
 
 export default function UserVerification() {
   const queryClient = useQueryClient();
+  const [rejectingId, setRejectingId] = useState(null);
+  const [rejectReason, setRejectReason] = useState('');
 
-  const { data: users = [], isLoading } = useQuery({
-    queryKey: ['users-verification'],
-    // Exclude demo profiles (is_demo = true) — they need no verification
-    queryFn: () => supabase.from('profiles').select('*').eq('is_demo', false)
-  });
-
-  const verifyMutation = useMutation({
-    mutationFn: async ({ userId, email, verified }) => {
-      await supabase.from('profiles').update({
-        is_verified: verified,
-        verification_requested: false,
-      });
-      return { email, verified };
+  const { data: rows = [], isLoading } = useQuery({
+    queryKey: ['admin-verifications'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('profile_verifications')
+        .select(`
+          id, user_id, type, status, selfie_url, pose_challenge,
+          submitted_at, reviewed_at, reviewed_by, rejection_reason,
+          profile:profiles!profile_verifications_user_id_fkey (
+            id, display_name, full_name, avatar_url, is_verified, is_demo
+          )
+        `)
+        .order('submitted_at', { ascending: false })
+        .limit(PAGE_SIZE);
+      if (error) throw error;
+      return data || [];
     },
-    onSuccess: (data) => {
-      queryClient.invalidateQueries(['users-verification']);
-      toast.success(data.verified ? 'User verified' : 'Verification removed');
-    }
   });
 
-  const pendingVerifications = users.filter(u => u.verification_requested && !u.is_verified);
-  const verifiedUsers = users.filter(u => u.is_verified);
-  const unverifiedUsers = users.filter(u => !u.is_verified && !u.verification_requested);
+  const reviewMutation = useMutation({
+    mutationFn: async ({ id, userId, decision, reason }) => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) throw new Error('Not authenticated');
+
+      const updates = {
+        status:           decision,
+        reviewed_by:      user.id,
+        reviewed_at:      new Date().toISOString(),
+        rejection_reason: decision === 'rejected' ? (reason || null) : null,
+      };
+      const { error: vErr } = await supabase
+        .from('profile_verifications')
+        .update(updates)
+        .eq('id', id);
+      if (vErr) throw vErr;
+
+      if (decision === 'approved') {
+        const { error: pErr } = await supabase
+          .from('profiles')
+          .update({
+            is_verified:        true,
+            verification_level: 'basic',
+            verified_at:        new Date().toISOString(),
+          })
+          .eq('id', userId);
+        if (pErr) throw pErr;
+      }
+      return { decision };
+    },
+    onSuccess: ({ decision }) => {
+      queryClient.invalidateQueries({ queryKey: ['admin-verifications'] });
+      toast.success(decision === 'approved' ? 'User verified' : 'Verification rejected');
+      setRejectingId(null);
+      setRejectReason('');
+    },
+    onError: (err) => {
+      toast.error(err.message || 'Update failed');
+    },
+  });
+
+  const pending  = rows.filter((r) => r.status === 'pending' && !r.profile?.is_demo);
+  const approved = rows.filter((r) => r.status === 'approved');
+  const rejected = rows.filter((r) => r.status === 'rejected');
 
   if (isLoading) {
-    return <div className="text-white/60">Loading verifications...</div>;
+    return <div className="text-white/60">Loading verification queue…</div>;
   }
 
   return (
     <div className="space-y-6">
       {/* Stats */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="bg-[#FFEB3B]/10 border-2 border-[#FFEB3B] p-6">
-          <div className="flex items-center gap-3 mb-2">
-            <Clock className="w-5 h-5 text-[#FFEB3B]" />
-            <span className="text-xs uppercase tracking-wider text-white/60">Pending</span>
-          </div>
-          <div className="text-3xl font-black">{pendingVerifications.length}</div>
-        </div>
-        <div className="bg-[#39FF14]/10 border-2 border-[#39FF14] p-6">
-          <div className="flex items-center gap-3 mb-2">
-            <CheckCircle className="w-5 h-5 text-[#39FF14]" />
-            <span className="text-xs uppercase tracking-wider text-white/60">Verified</span>
-          </div>
-          <div className="text-3xl font-black">{verifiedUsers.length}</div>
-        </div>
-        <div className="bg-white/10 border-2 border-white/20 p-6">
-          <div className="flex items-center gap-3 mb-2">
-            <User className="w-5 h-5 text-white/60" />
-            <span className="text-xs uppercase tracking-wider text-white/60">Unverified</span>
-          </div>
-          <div className="text-3xl font-black">{unverifiedUsers.length}</div>
-        </div>
+        <Stat icon={Clock}       color="#FFEB3B" label="Pending"  value={pending.length}  />
+        <Stat icon={CheckCircle} color="#39FF14" label="Approved" value={approved.length} />
+        <Stat icon={XCircle}     color="#FF3B30" label="Rejected" value={rejected.length} />
       </div>
 
-      {/* Pending Verifications */}
-      {pendingVerifications.length > 0 && (
-        <div>
-          <h3 className="text-lg font-black uppercase mb-4">Pending Verifications</h3>
-          <div className="space-y-3">
-            {pendingVerifications.map((user, idx) => (
-              <motion.div
-                key={user.id}
-                initial={{ opacity: 0, x: -20 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={{ delay: idx * 0.05 }}
-                className="bg-white/5 border border-white/10 rounded-xl p-4"
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-4">
-                    <div className="w-12 h-12 rounded-full bg-gradient-to-br from-[#C8962C] to-[#C8962C] flex items-center justify-center overflow-hidden">
-                      {user.avatar_url ? (
-                        <img src={user.avatar_url} alt={user.full_name} className="w-full h-full object-cover" />
-                      ) : (
-                        <span className="text-lg font-bold">{user.full_name?.[0] || 'U'}</span>
-                      )}
-                    </div>
-                    <div>
-                      <div className="flex items-center gap-2">
-                        <p className="font-bold">{user.full_name}</p>
-                        <Badge className="bg-[#FFEB3B] text-black text-xs">
-                          Pending
-                        </Badge>
+      {/* Pending */}
+      <div>
+        <h3 className="text-lg font-black uppercase mb-4">Pending Review</h3>
+        {pending.length === 0 && (
+          <p className="text-white/40 text-sm">Inbox zero. No pending submissions.</p>
+        )}
+        <div className="space-y-3">
+          {pending.map((row, idx) => (
+            <motion.div
+              key={row.id}
+              initial={{ opacity: 0, x: -20 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ delay: idx * 0.05 }}
+              className="bg-white/5 border border-white/10 rounded-xl p-4"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex items-start gap-4 flex-1 min-w-0">
+                  {/* Submitted selfie */}
+                  <div className="w-20 h-20 rounded-xl overflow-hidden bg-white/5 flex-shrink-0 border border-white/10">
+                    {row.selfie_url ? (
+                      <img src={row.selfie_url} alt="Submitted selfie" className="w-full h-full object-cover" />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center text-white/30 text-xs">
+                        No selfie
                       </div>
-                      <p className="text-xs text-white/40">{user.id}</p>
-                      <p className="text-xs text-white/60 mt-1">
-                        {user.membership_tier || 'free'}
-                      </p>
-                    </div>
+                    )}
                   </div>
+
+                  {/* User profile photo */}
+                  <div className="w-20 h-20 rounded-xl overflow-hidden bg-gradient-to-br from-[#C8962C]/20 to-black flex-shrink-0 border border-white/10">
+                    {row.profile?.avatar_url ? (
+                      <img src={row.profile.avatar_url} alt="Profile photo" className="w-full h-full object-cover" />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center">
+                        <User className="w-8 h-8 text-white/30" />
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <p className="font-bold truncate">
+                        {row.profile?.full_name || row.profile?.display_name || 'Unknown user'}
+                      </p>
+                      <Badge className="bg-[#FFEB3B] text-black text-xs">Pending</Badge>
+                    </div>
+                    <p className="text-xs text-white/40">Submitted {timeAgo(row.submitted_at)}</p>
+                    {row.pose_challenge && (
+                      <p className="text-xs text-white/60 mt-1">
+                        Pose: <span className="text-white/80">{row.pose_challenge.replace(/_/g, ' ')}</span>
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                <div className="flex flex-col gap-2 flex-shrink-0">
+                  <Button
+                    onClick={() => reviewMutation.mutate({ id: row.id, userId: row.user_id, decision: 'approved' })}
+                    disabled={reviewMutation.isPending}
+                    className="bg-[#39FF14] text-black font-bold"
+                  >
+                    <CheckCircle className="w-4 h-4 mr-1" />
+                    Approve
+                  </Button>
+                  <Button
+                    onClick={() => setRejectingId(row.id)}
+                    variant="outline"
+                    className="border-red-600 text-red-600"
+                  >
+                    <XCircle className="w-4 h-4 mr-1" />
+                    Reject
+                  </Button>
+                </div>
+              </div>
+
+              {rejectingId === row.id && (
+                <div className="mt-4 pt-4 border-t border-white/10 space-y-2">
+                  <label className="text-xs uppercase tracking-wider text-white/50">Reason (shown to user)</label>
+                  <input
+                    type="text"
+                    value={rejectReason}
+                    onChange={(e) => setRejectReason(e.target.value)}
+                    maxLength={200}
+                    placeholder="e.g. Selfie does not match profile photos"
+                    className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder-white/25 outline-none focus:border-red-500/50"
+                  />
                   <div className="flex gap-2">
                     <Button
-                      onClick={() => verifyMutation.mutate({ userId: user.id, email: user.email, verified: true })}
-                      className="bg-[#39FF14] text-black font-bold"
+                      onClick={() => reviewMutation.mutate({
+                        id: row.id, userId: row.user_id, decision: 'rejected', reason: rejectReason.trim(),
+                      })}
+                      disabled={!rejectReason.trim() || reviewMutation.isPending}
+                      className="bg-red-600 text-white font-bold"
                     >
-                      <CheckCircle className="w-4 h-4 mr-1" />
-                      Verify
+                      Confirm Rejection
                     </Button>
                     <Button
-                      onClick={() => verifyMutation.mutate({ userId: user.id, email: user.email, verified: false })}
+                      onClick={() => { setRejectingId(null); setRejectReason(''); }}
                       variant="outline"
-                      className="border-red-600 text-red-600"
+                      className="border-white/20 text-white/70"
                     >
-                      <XCircle className="w-4 h-4 mr-1" />
-                      Reject
+                      Cancel
                     </Button>
                   </div>
                 </div>
-              </motion.div>
+              )}
+            </motion.div>
+          ))}
+        </div>
+      </div>
+
+      {/* Recently approved (last 10) */}
+      {approved.length > 0 && (
+        <div>
+          <h3 className="text-lg font-black uppercase mb-4">
+            Recently Approved <span className="text-white/40">({approved.length})</span>
+          </h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {approved.slice(0, 10).map((row) => (
+              <div
+                key={row.id}
+                className="bg-[#39FF14]/10 border border-[#39FF14]/40 rounded-xl p-3 flex items-center gap-3"
+              >
+                <CheckCircle className="w-5 h-5 text-[#39FF14] flex-shrink-0" />
+                <div className="min-w-0">
+                  <p className="font-bold text-sm truncate">
+                    {row.profile?.full_name || row.profile?.display_name || 'Unknown'}
+                  </p>
+                  <p className="text-xs text-white/40">
+                    Reviewed {timeAgo(row.reviewed_at)}
+                  </p>
+                </div>
+              </div>
             ))}
           </div>
         </div>
       )}
+    </div>
+  );
+}
 
-      {/* Verified Users */}
-      <div>
-        <h3 className="text-lg font-black uppercase mb-4">Verified Users ({verifiedUsers.length})</h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {verifiedUsers.slice(0, 10).map((user) => (
-            <div key={user.id} className="bg-[#39FF14]/10 border border-[#39FF14]/40 rounded-xl p-4 flex items-center gap-3">
-              <CheckCircle className="w-5 h-5 text-[#39FF14]" />
-              <div>
-                <p className="font-bold text-sm">{user.full_name}</p>
-                <p className="text-xs text-white/40">{user.id}</p>
-              </div>
-            </div>
-          ))}
-        </div>
+function Stat({ icon: Icon, color, label, value }) {
+  return (
+    <div
+      className="border-2 p-6"
+      style={{ background: `${color}10`, borderColor: color }}
+    >
+      <div className="flex items-center gap-3 mb-2">
+        <Icon className="w-5 h-5" style={{ color }} />
+        <span className="text-xs uppercase tracking-wider text-white/60">{label}</span>
       </div>
+      <div className="text-3xl font-black">{value}</div>
     </div>
   );
 }

--- a/src/components/verification/SelfieVerificationFlow.jsx
+++ b/src/components/verification/SelfieVerificationFlow.jsx
@@ -131,27 +131,19 @@ export default function SelfieVerificationFlow({ onComplete, onDismiss }) {
       const poseFile = new File([poseBlob], `verification_pose_${Date.now()}.jpg`, { type: 'image/jpeg' });
       await uploadToStorage(poseFile, 'avatars', `${user.id}/verification`);
 
-      // Write verification record
-      await supabase.from('profile_verifications').insert({
+      // Write verification record (admin reviews before is_verified flips)
+      const { error: insertErr } = await supabase.from('profile_verifications').insert({
         user_id: user.id,
         type: 'selfie',
-        status: 'approved', // Auto-approve selfie submissions (manual review can override later)
+        status: 'pending',
         selfie_url: selfieUrl,
         pose_challenge: challenge.key,
         submitted_at: new Date().toISOString(),
-        reviewed_at: new Date().toISOString(),
       });
-
-      // Update profile verification status
-      await supabase.from('profiles').update({
-        is_verified: true,
-        verification_level: 'basic',
-        verified_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      }).eq('id', user.id);
+      if (insertErr) throw insertErr;
 
       setStep('success');
-      toast.success('You\'re verified!');
+      toast.success('Submitted for review');
     } catch (err) {
       console.error('[Verification] submit failed:', err);
       setError(err.message || 'Verification failed. Please try again.');
@@ -291,9 +283,9 @@ export default function SelfieVerificationFlow({ onComplete, onDismiss }) {
         <div className="w-16 h-16 rounded-full flex items-center justify-center mb-6" style={{ backgroundColor: `${GOLD}20` }}>
           <CheckCircle className="w-8 h-8" style={{ color: GOLD }} />
         </div>
-        <h2 className="text-white text-xl font-bold mb-2">You're Verified</h2>
+        <h2 className="text-white text-xl font-bold mb-2">Submitted</h2>
         <p className="text-white/50 text-sm text-center mb-8 max-w-[260px]">
-          Your badge is now live. Other users can see you're a real person.
+          A real human reviews every selfie. You'll get a notification within 24 hours when your badge is live.
         </p>
         <button
           onClick={() => onComplete?.()}

--- a/src/pages/admin/VerificationQueue.jsx
+++ b/src/pages/admin/VerificationQueue.jsx
@@ -1,0 +1,78 @@
+/**
+ * /admin/verification — admin queue for selfie verification submissions.
+ *
+ * Auth: client-side gate is decorative; the real lock is RLS on
+ * profile_verifications (admin SELECT/UPDATE require profiles.is_admin).
+ */
+
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Shield } from 'lucide-react';
+import { supabase } from '@/components/utils/supabaseClient';
+import UserVerification from '@/components/admin/UserVerification';
+
+export default function VerificationQueue() {
+  const navigate = useNavigate();
+  const [state, setState] = useState({ loading: true, isAdmin: false });
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) {
+        if (active) setState({ loading: false, isAdmin: false });
+        return;
+      }
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('is_admin')
+        .eq('id', user.id)
+        .maybeSingle();
+      if (active) setState({ loading: false, isAdmin: !!profile?.is_admin });
+    })();
+    return () => { active = false; };
+  }, []);
+
+  if (state.loading) {
+    return (
+      <div className="min-h-screen bg-[#050507] text-white flex items-center justify-center">
+        <Shield className="w-10 h-10 text-white/40 animate-pulse" />
+      </div>
+    );
+  }
+
+  if (!state.isAdmin) {
+    return (
+      <div className="min-h-screen bg-[#050507] text-white flex items-center justify-center p-6">
+        <div className="text-center max-w-sm">
+          <Shield className="w-12 h-12 text-white/30 mx-auto mb-4" />
+          <h1 className="text-xl font-black mb-2">Admin only</h1>
+          <p className="text-white/50 text-sm mb-6">
+            You don't have access to this page.
+          </p>
+          <button
+            onClick={() => navigate('/')}
+            className="px-5 py-2.5 rounded-xl bg-[#C8962C] text-black font-bold text-sm"
+          >
+            Go home
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[#050507] text-white">
+      <div className="max-w-5xl mx-auto px-4 py-8 pb-32">
+        <header className="mb-8">
+          <p className="text-[10px] uppercase tracking-widest text-white/40 font-mono">Admin</p>
+          <h1 className="text-2xl font-black uppercase">Verification Queue</h1>
+          <p className="text-white/50 text-sm mt-1">
+            Selfie submissions awaiting human review.
+          </p>
+        </header>
+        <UserVerification />
+      </div>
+    </div>
+  );
+}

--- a/supabase/migrations/20260507000005_verification_flow.sql
+++ b/supabase/migrations/20260507000005_verification_flow.sql
@@ -1,0 +1,40 @@
+-- MEGA-3 §3.4: verification submission flow
+-- Existing table profile_verifications already has selfie_url, status,
+-- submitted_at, reviewed_at, expires_at. Add the admin-review columns
+-- the brief specifies (reviewed_by, rejection_reason) and the RLS
+-- policies the admin queue needs.
+
+ALTER TABLE public.profile_verifications
+  ADD COLUMN IF NOT EXISTS reviewed_by      uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS rejection_reason text;
+
+-- Admin queue: read all (own + admin) + update for approve/reject (admin only)
+DROP POLICY IF EXISTS "verifications_admin_select" ON public.profile_verifications;
+CREATE POLICY "verifications_admin_select"
+  ON public.profile_verifications FOR SELECT
+  USING (
+    auth.uid() = user_id
+    OR EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND is_admin = true)
+  );
+
+-- The pre-existing per-user SELECT policy is replaced by the union above.
+DROP POLICY IF EXISTS "Users can read own verifications" ON public.profile_verifications;
+
+DROP POLICY IF EXISTS "verifications_admin_update" ON public.profile_verifications;
+CREATE POLICY "verifications_admin_update"
+  ON public.profile_verifications FOR UPDATE
+  USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND is_admin = true)
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND is_admin = true)
+  );
+
+CREATE INDEX IF NOT EXISTS idx_profile_verifications_status_submitted
+  ON public.profile_verifications (status, submitted_at)
+  WHERE status = 'pending';
+
+COMMENT ON COLUMN public.profile_verifications.reviewed_by IS
+  'auth.users.id of the admin who approved/rejected this submission. NULL for pending.';
+COMMENT ON COLUMN public.profile_verifications.rejection_reason IS
+  'Set when status=rejected. Shown to the user on resubmit.';


### PR DESCRIPTION
## Summary

End-to-end selfie verification flow with an admin review queue.

### Migration
Backed by the existing `public.profile_verifications` table. Adds the admin-review columns the spec calls for (`reviewed_by` FK to `auth.users`, `rejection_reason`) plus the RLS the queue needs:
- **SELECT**: own user OR admin
- **UPDATE**: admin only
- partial index on `(status='pending', submitted_at)` for queue scan

### Frontend
- `SelfieVerificationFlow` now writes `status='pending'` and **does not** flip `profiles.is_verified` — that happens only on admin approve. Success screen reframed: *"A real human reviews every selfie. You'll get a notification within 24 hours when your badge is live."*
- `UserVerification` rewritten as a real queue: side-by-side selfie + profile photo, approve writes `is_verified` + `verified_at`, reject takes a reason that's surfaced to the user on resubmit. Demo accounts (`is_demo=true`) filtered out.
- New `/admin/verification` route wraps the queue with a client-side admin gate (the real gate is RLS).

## Test plan

- [x] Migration applied to prod
- [x] `npm run lint` green
- [x] `npm run typecheck` green
- [ ] Manual: e2e.alpha submits a selfie → /admin/verification shows it → Phil approves → e2e.alpha's profile shows the verified badge
- [ ] Manual: reject path → user sees the reason on the next submission attempt

## Note on `verification_requests`

The brief named the table `verification_requests`; we already had `profile_verifications` with the same shape, so this PR extends that rather than duplicating. Same status values, same selfie_url + reviewed_at semantics.