### PR TITLE
fix(livemode): remove duplicate useCallback handlers (#310 cleanup)

### DIFF
--- a/src/components/live/LiveModeOverlay.tsx
+++ b/src/components/live/LiveModeOverlay.tsx
@@ -49,6 +49,36 @@ export default function LiveModeOverlay() {
   const reduced = useReducedMotion();
   const [activeChipId, setActiveChipId] = useState<string | null>(null);
 
+  // ── Action handlers ────────────────────────────────────────────────────────
+  // Hooks MUST be declared before any conditional return (React #310). Keep
+  // these here even though they only fire while live; moving them below the
+  // early-return on `!isLive` causes the hook count to jump 5→10 the moment
+  // Go Live flips on, which crashes the app.
+
+  const handlePing = useCallback((user: LiveUser) => {
+    openSheet('chat', { userId: user.id, prefill: '👋' });
+  }, [openSheet]);
+
+  const handlePullUp = useCallback((user: LiveUser) => {
+    openSheet('profile', { uid: user.id });
+  }, [openSheet]);
+
+  const handleMeetHalfway = useCallback((user: LiveUser) => {
+    openSheet('profile', { uid: user.id });
+  }, [openSheet]);
+
+  const handleAction = useCallback((user: LiveUser) => {
+    switch (user.primaryAction) {
+      case 'ping': return handlePing(user);
+      case 'pull_up': return handlePullUp(user);
+      case 'meet_halfway': return handleMeetHalfway(user);
+    }
+  }, [handlePing, handlePullUp, handleMeetHalfway]);
+
+  const handleChipTap = useCallback((chip: ContextChip) => {
+    setActiveChipId(prev => prev === chip.id ? null : chip.id);
+  }, []);
+
   if (!isLive || !liveContext) return null;
 
   const moment = data ?? {
@@ -89,33 +119,6 @@ export default function LiveModeOverlay() {
   const subline = subParts.join(' \u00B7 ') || 'Scanning...';
 
   const isVenueLayout = liveContext.type === 'venue';
-
-  // ── Action handlers ────────────────────────────────────────────────────────
-
-  const handlePing = useCallback((user: LiveUser) => {
-    openSheet('chat', { userId: user.id, prefill: '\uD83D\uDC4B' });
-  }, [openSheet]);
-
-  const handlePullUp = useCallback((user: LiveUser) => {
-    openSheet('profile', { uid: user.id });
-  }, [openSheet]);
-
-  const handleMeetHalfway = useCallback((user: LiveUser) => {
-    openSheet('profile', { uid: user.id });
-  }, [openSheet]);
-
-  const handleAction = useCallback((user: LiveUser) => {
-    switch (user.primaryAction) {
-      case 'ping': return handlePing(user);
-      case 'pull_up': return handlePullUp(user);
-      case 'meet_halfway': return handleMeetHalfway(user);
-    }
-  }, [handlePing, handlePullUp, handleMeetHalfway]);
-
-  const handleChipTap = useCallback((chip: ContextChip) => {
-    setActiveChipId(prev => prev === chip.id ? null : chip.id);
-  }, []);
-
   // ── Render ─────────────────────────────────────────────────────────────────
 
   return (


### PR DESCRIPTION
## Summary
Resolves the MEGA-1.1 partial-fix concurrency conflict.

stash@{1} (\`mega1-livemode-partial-fix-not-mine\`) added 5 useCallback handlers ABOVE the \`if (!isLive || !liveContext) return null;\` early-return so the hook count stays stable when \`isLive\` flips false→true (React #310). The OLD handlers below the early-return were left in place by mistake, producing 5 duplicate declarations and double-allocations on every render.

This PR pops that stash, applies the new top-of-component declarations, and deletes lines 122–148 (the duplicate block). Final state:
- 5 handlers live before the early return on line 82
- Zero duplicates after
- Hook count stable at component-mount: 10 → 10 (was 5 → 10)

## Verification
- \`npm run lint\` ✓
- \`npm run typecheck\` ✓
- \`grep -n "useCallback" src/components/live/LiveModeOverlay.tsx\` shows 5 hooks at lines 58–78, none after line 82.

## Test plan
- [x] Lint + typecheck green
- [ ] Manual: tap "Go Live" in \`?sheet=go-live\`, confirm no React #310 crash, \`right_now_status\` row written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the live mode overlay component's internal logic to improve code reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->