### PR TITLE
[MEGA-1.2] Add /fake-call route so the page is reachable

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -460,6 +460,7 @@ const AuthenticatedApp = () => {
       <Route path="/safety" element={<Suspense fallback={<PageLoadingSkeleton type="feed" />}><SafetyPage /></Suspense>} />
       <Route path="/safety/*" element={<Suspense fallback={<PageLoadingSkeleton type="feed" />}><SafetyPage /></Suspense>} />
       <Route path="/safe" element={<Suspense fallback={null}><SafePage /></Suspense>} />
+      <Route path="/fake-call" element={<Suspense fallback={null}><FakeCallPage /></Suspense>} />
 
       
       {/* AUTH & INFRASTRUCTURE */}


### PR DESCRIPTION
## Summary
\`FakeCallPage\` was lazy-imported in \`src/App.jsx\` (line 87) but had no \`<Route>\` registered. Direct visit to \`/fake-call\` returned 404, making the "I need an out" feature unreachable.

Adds a single route line right after \`/safe\` so the page sits among the other safety surfaces. Auth gating inherits from the global BootGuard tree (same as \`/safety\`, \`/safe\`, etc.).

## Verification
- \`npm run lint\` ✓
- \`npm run typecheck\` ✓
- New line: \`<Route path="/fake-call" element={<Suspense fallback={null}><FakeCallPage /></Suspense>} />\`

## Test plan
- [x] Lint + typecheck green
- [ ] Logged in: visit \`/fake-call\` → page renders, dismiss flow works
- [ ] Logged out: redirects to splash via BootGuard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `/fake-call` page accessible to authenticated users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->