### PR TITLE
[MEGA-1.3] Rename More-menu 'Taps' label to 'Boos'

### DIFF
--- a/src/pages/MorePage.tsx
+++ b/src/pages/MorePage.tsx
@@ -596,7 +596,7 @@ export default function MorePage() {
   // ── Quick items with live counts ──────────────────────────────────────
 
   const youItems: QuickItem[] = useMemo(() => [
-    { icon: Heart, label: 'Taps', count: activity.tapCount, onTap: () => openSheet('taps'), accent: '#FF5500' },
+    { icon: Heart, label: 'Boos', count: activity.tapCount, onTap: () => openSheet('taps'), accent: '#FF5500' },
     { icon: Ticket, label: 'Orders', count: activity.pendingOrders, onTap: () => openSheet('my-orders'), accent: GOLD },
     { icon: ShoppingBag, label: 'My Listings', count: activity.liveListings, onTap: () => openSheet('my-listings'), accent: '#9E7D47' },
     { icon: Bookmark, label: 'Saved', onTap: () => openSheet('favorites'), accent: GOLD },


### PR DESCRIPTION
## Summary
The More menu was the last UI surface calling it "Taps". Everywhere else the action speaks Boos:
- Toast on tap: "Boo sent"
- \`L2TapsSheet\` header: "Boo'd you"
- Action verb: "boo"
- Subject line in lists: "Boo'd you · 5m ago"

Renames the single user-facing label in \`src/pages/MorePage.tsx:599\` from \`'Taps'\` to \`'Boos'\`. Everything downstream (DB \`taps\` table, \`openSheet('taps')\`, variable names) is intentionally untouched per the brief — only the visible label changes.

Grep confirms zero other user-facing \`Taps\` strings exist.

## Verification
- \`npm run lint\` ✓
- \`npm run typecheck\` ✓
- \`grep -rn ">Taps<|label.*Taps|title.*Taps" src/\` returns empty after edit

## Test plan
- [x] Lint + typecheck green
- [ ] Open More menu — first item under "Quick" reads "Boos"
- [ ] Tap it — opens the existing taps sheet (which still reads from \`taps\` table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)