### PR TITLE
fix(pulse): membership upsert writes correct `tier` column (P0-5)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -410,7 +410,7 @@ const AuthenticatedApp = () => {
 
           await supabase.from('memberships').upsert({
             user_id: user.id,
-            tier_name: tierKey,
+            tier: tierKey,
             updated_at: new Date().toISOString()
           }, { onConflict: 'user_id' });
 


### PR DESCRIPTION
## Summary
**Revenue-path bug.** The Stripe redirect handler in \`AuthenticatedApp\` upserted to a non-existent column (\`tier_name\`), so the first paying customer's membership row silently had no usable tier value. Every read path (\`has_xxx_access\`, gating, tier badge) reads \`tier\`, so the upsert effectively did nothing.

## Schema verified (rfoftonnlwudilafhfkl, 2026-05-08)
\`\`\`
memberships columns:
  id, user_id, tier (text), status, started_at, ends_at,
  metadata, tier_id (int), payment_provider, updated_at
\`\`\`
**No \`tier_name\` column exists.**

## Diff
\`\`\`diff
- await supabase.from('memberships').upsert({
-   user_id: user.id,
-   tier_name: tierKey,
+ await supabase.from('memberships').upsert({
+   user_id: user.id,
+   tier: tierKey,
    updated_at: new Date().toISOString()
  }, { onConflict: 'user_id' });
\`\`\`

## Sibling sites (NOT bundled — dispatch said one PR per fix)
The grep turned up 3 other \`tier_name\` references that need a follow-up wave:
- \`src/components/sheets/L2MembershipSheet.jsx:179\` — same upsert pattern, almost certainly the same bug
- \`api/stripe/create-checkout-session.js:302\` — write to \`memberships\` from server side
- \`api/stripe/webhook.js:126\` — reads \`session.metadata?.tier_name\`, which may be intentional (Stripe metadata is free-form, not tied to DB schema)

## Test plan
- [x] \`npm run lint\` ✓
- [x] \`npm run typecheck\` ✓
- [x] Schema verified live: \`tier\` exists, \`tier_name\` does not
- [ ] After merge: complete a Stripe checkout for a new user → \`SELECT user_id, tier, status FROM memberships WHERE user_id = '...'\` returns the correct tier (was NULL/missing before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed membership tier information not being saved correctly after successful Stripe payment processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->