### PR TITLE
fix(pulse): remove dead UserActivity realtime channel (P0-3)

### DIFF
--- a/src/pages/Globe.jsx
+++ b/src/pages/Globe.jsx
@@ -178,48 +178,13 @@ export default function GlobePage({ embedded = false }) {
     refetchInterval: 30000 // Refresh every 30 seconds
   });
 
-  // Real-time subscriptions for user activities
-  useEffect(() => {
-    // Fetch recent activities
-    const fetchActivities = async () => {
-      try {
-        const { data: activities } = await supabase.from('user_activity').select('*').order('created_date', { ascending: false }).limit(50);
-        if (activities) {
-          setUserActivities(activityTracker.pruneOldActivities(activities));
-        }
-      } catch (error) {
-        console.error('Failed to fetch activities:', error);
-      }
-    };
-
-    fetchActivities();
-
-    const activityChannel = supabase
-      .channel('user-activities-realtime')
-      .on(
-        'postgres_changes',
-        { event: 'INSERT', schema: 'public', table: 'UserActivity' },
-        (payload) => {
-          if (payload.new.visible) {
-            setUserActivities((old) => {
-              const updated = [payload.new, ...old];
-              return activityTracker.pruneOldActivities(updated);
-            });
-          }
-        }
-      )
-      .subscribe();
-
-    // Prune old activities every 10 seconds
-    const pruneInterval = setInterval(() => {
-      setUserActivities((old) => activityTracker.pruneOldActivities(old));
-    }, 10000);
-
-    return () => {
-      supabase.removeChannel(activityChannel);
-      clearInterval(pruneInterval);
-    };
-  }, []);
+  // Activity-tracker realtime channel removed 2026-05-08: subscribed to a
+  // public.UserActivity table that does not exist in production, and
+  // fetchActivities() queried public.user_activity which also does not exist.
+  // Both reads silently returned no data. The write-side activityTracker
+  // .trackActivity() calls are kept on event handlers for when the feature
+  // is re-architected (Path B in PULSE_AUDIT_2026_05_08.md). When that lands,
+  // re-introduce the channel + state here.
 
   const [activeLayers, setActiveLayers] = useState(['pins']);
   const [debouncedLayers, setDebouncedLayers] = useState(['pins']);
@@ -240,7 +205,6 @@ export default function GlobePage({ embedded = false }) {
   const [recencyFilter, setRecencyFilter] = useState('all');
   const [searchResults, setSearchResults] = useState(null);
   const [radiusSearch, setRadiusSearch] = useState(null);
-  const [userActivities, setUserActivities] = useState([]);
   const [activityVisibility, setActivityVisibility] = useState(activityTracker.isEnabled());
   const [userLocation, setUserLocation] = useState(null);
   const [previewBeacon, setPreviewBeacon] = useState(null);
@@ -637,7 +601,6 @@ export default function GlobePage({ embedded = false }) {
             venueIntensity={venueIntensity}
             venueVibes={venueVibes}
             activeLayers={debouncedLayers}
-            userActivities={userActivities}
             userIntents={userIntents}
             routesData={realtimeRoutes}
             globeActivity={globeActivity}


### PR DESCRIPTION
## Summary
The \`/pulse\` page had a \`useEffect\` that:
1. Queried \`supabase.from('user_activity').select()\` on mount
2. Subscribed to a \`postgres_changes\` channel filtered to \`public.UserActivity\`

**Neither table exists in production.** Verified via \`information_schema.tables\` — zero rows match \`table_name ILIKE '%activity%'\` in \`rfoftonnlwudilafhfkl\`. The fetch silently returned no rows; the realtime channel was a permanently-quiet listener holding a websocket slot for nothing.

## Path A (this PR)
Surgical cleanup. Path B (re-create the table + re-architect the visual reactor) is intentionally deferred per the dispatch — that's a deliberate feature build, not a fix.

### Removed
- \`useEffect\` that creates \`fetchActivities\` + \`activityChannel\` + \`pruneInterval\` (Globe.jsx:181–222)
- \`userActivities\` / \`setUserActivities\` state (line 243)
- \`userActivities\` prop on \`EnhancedGlobe3D\` (line 640) — confirmed unused inside \`EnhancedGlobe3D.jsx\` (no destructure, no reference), so dropping the prop is a no-op visually

### Kept (decorative, future-proof)
- \`activityTracker.trackActivity()\` write-side calls in event handlers. They wrap their inserts in \`try/catch\` and fail silently against the missing table — harmless dead code now, and they become live again the moment Path B lands. No reason to rip them out.
- \`activityVisibility\` state + toggle — drives a localStorage-backed UX setting that's independent of the realtime feature.

## Test plan
- [x] \`grep "userActivities|setUserActivities|activityChannel|fetchActivities|UserActivity"\` returns only the new explanatory comment (no live refs)
- [x] \`npm run lint\` ✓
- [x] \`npm run typecheck\` ✓
- [ ] After merge: visit /pulse, open DevTools → Network → WS — should NOT see a \`user-activities-realtime\` channel subscription

🤖 Generated with [Claude Code](https://claude.com/claude-code)