### PR TITLE
fix(pulse): BottomNav comment matches code (7 modes) (P0-1)

### DIFF
--- a/src/components/navigation/BottomNav.jsx
+++ b/src/components/navigation/BottomNav.jsx
@@ -15,9 +15,13 @@ import { useSheet } from '@/contexts/SheetContext';
 
 /**
  * BottomNav — L1 HUD Navigation (z-50)
- * 
+ *
  * RULES:
- * 1. Exactly 6 modes: Home, Pulse, Ghosted, Shop, Profile, More
+ * 1. Exactly 7 modes: Home, Pulse, Ghosted, Shop, Inbox, Profile, More.
+ *    (Inbox is a sheet-action slot — see `isSheetAction: 'chat'` below — but
+ *    it occupies a permanent bar position because unread count drives engagement.
+ *    If product later decides Inbox should move to long-press / top-bar, drop
+ *    the row from MODES below and update this rule back to 6.)
  * 2. 44px minimum touch targets (WCAG 2.1)
  * 3. No nested navigation or modals
  * 4. Active state indicated by color + top bar


### PR DESCRIPTION
## Summary
The \`MODES\` array on \`src/components/navigation/BottomNav.jsx:28\` has **7 entries**: Home, Pulse, Ghosted, Shop, Inbox, Profile, More. The JSDoc comment above said \"Exactly 6 modes\" and only enumerated 6 (Inbox missing). Future contributors reading the file would not know whether the comment or the code is canonical, and might silently delete Inbox to satisfy the comment.

Per the dispatch's product call: **keep 7 slots, fix the comment.** If product later decides Inbox should move to long-press / top-bar, that's a separate PR that drops the row and reverts the rule.

## Diff
\`\`\`diff
- * 1. Exactly 6 modes: Home, Pulse, Ghosted, Shop, Profile, More
+ * 1. Exactly 7 modes: Home, Pulse, Ghosted, Shop, Inbox, Profile, More.
+ *    (Inbox is a sheet-action slot — see \`isSheetAction: 'chat'\` below — but
+ *    it occupies a permanent bar position because unread count drives engagement.
+ *    If product later decides Inbox should move to long-press / top-bar, drop
+ *    the row from MODES below and update this rule back to 6.)
\`\`\`

## Test plan
- [x] \`grep "Exactly 6 modes|Exactly 7 modes" src/\` returns only the new line
- [x] \`npm run lint\` ✓
- [x] \`npm run typecheck\` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)