### PR TITLE
fix(membership): L2MembershipSheet upsert writes correct `tier` column (sibling of #240)

### DIFF
--- a/src/components/sheets/L2MembershipSheet.jsx
+++ b/src/components/sheets/L2MembershipSheet.jsx
@@ -176,7 +176,7 @@ export default function L2MembershipSheet() {
           .from('memberships')
           .upsert({
             user_id: user.id,
-            tier_name: tierName,
+            tier: tierName,
             updated_at: new Date().toISOString()
           }, { onConflict: 'user_id' });
 


### PR DESCRIPTION
Sibling of #240. The post-payment fallback upsert in `L2MembershipSheet.jsx:179` wrote to non-existent column `tier_name`. Same root cause as App.jsx — `memberships.tier` is the canonical column.

Verified live (rfoftonnlwudilafhfkl): `memberships` columns are `id, user_id, tier (text), status, started_at, ends_at, metadata, tier_id (int), payment_provider, updated_at`. No `tier_name`.

## Test plan
- [x] `npm run lint` ✓
- [x] `npm run typecheck` ✓
- [x] After this lands: zero `tier_name` DB-column writes remain in src/. The two remaining `tier_name` references are Stripe metadata keys (handled in next follow-up).

🤖 Overnight dispatch — wave A.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where membership tier upgrades were not being properly saved to user accounts during payment completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->