### PR TITLE
fix(stripe): align metadata key 'tier_name' → 'tier' (matches DB column)

### DIFF
--- a/api/stripe/create-checkout-session.js
+++ b/api/stripe/create-checkout-session.js
@@ -299,7 +299,7 @@ export default async function handler(req, res) {
         user_email: user.email ?? '',
         user_name: profile?.display_name ?? '',
         tier_id: String(tier.id),
-        tier_name: tier.name,
+        tier: tier.name,
         type: 'membership',
       },
       return_url: `${origin}/more/settings?membership=success&tier=${encodeURIComponent(tier.name)}&session_id={CHECKOUT_SESSION_ID}`,

--- a/api/stripe/webhook.js
+++ b/api/stripe/webhook.js
@@ -123,7 +123,9 @@ async function processOrderCompletion(session, eventType, req) {
   // ── Handle Membership Upgrades ──────────────────────────────────────────
   if (stripeType === 'membership') {
     const userId = session.metadata?.user_id;
-    const tierName = session.metadata?.tier_name;
+    // Read either key for backward-compat: sessions started before this rename
+    // still carry tier_name; new sessions use tier (matches the DB column name).
+    const tierName = session.metadata?.tier ?? session.metadata?.tier_name;
 
     if (!userId || !tierName) {
       console.error('[Webook] Missing membership metadata:', { userId, tierName });


### PR DESCRIPTION
Wave A.3 of the overnight dispatch. The Stripe metadata key was `tier_name` but the DB column it maps to is `tier`. The mismatch wasn't breaking anything (Stripe metadata is free-form and the webhook reader consistently used the matching key), but it created a surface where the wrong name could leak back into a DB write — exactly what happened in #240 / #243.

Changes:
- `api/stripe/create-checkout-session.js` — metadata.tier_name → metadata.tier
- `api/stripe/webhook.js` — reads session.metadata?.tier first, falls back to session.metadata?.tier_name so any in-flight Stripe sessions created before this rename still complete cleanly.

After this lands, zero `tier_name` references remain in src/ + api/ except the backward-compat fallback in webhook.js. Once in-flight pre-rename Stripe sessions have settled (sessions expire in 24h), that fallback can be dropped.

## Test plan
- [x] `grep -rn "tier_name" src/ api/` returns only the documented backward-compat fallback
- [x] `npm run lint` ✓
- [x] `npm run typecheck` ✓

🤖 Overnight dispatch — wave A.3 (collapses A.2)