### PR TITLE
fix(security): remove hardcoded Google Maps API key fallback

### DIFF
--- a/src/hooks/useGPS.ts
+++ b/src/hooks/useGPS.ts
@@ -102,23 +102,27 @@ export function useGPS(autoUpdate = true): UseGPSResult {
 
       // ── Reverse Geocode for Area Name ──────────────────────────────────────
       let locationArea = null;
-      try {
-        const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY || 'AIzaSyDZBzKf5oO1zhdQph9F5j_1JUihMkFQXM0';
-        const response = await fetch(
-          `https://maps.googleapis.com/maps/api/geocode/json?latlng=${newPosition.lat},${newPosition.lng}&key=${apiKey}&result_type=neighborhood|sublocality|locality`
-        );
-        const geoData = await response.json();
-        if (geoData.status === 'OK' && geoData.results?.length > 0) {
-          // Find the most descriptive "neighborhood" or "sublocality"
-          const bestMatch = geoData.results.find(r => r.types.includes('neighborhood')) 
-                        || geoData.results.find(r => r.types.includes('sublocality'))
-                        || geoData.results[0];
-          
-          locationArea = bestMatch.address_components[0].long_name;
-          console.log('[useGPS] 📍 Reverse geocoded area:', locationArea);
+      const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+      if (!apiKey) {
+        console.warn('[useGPS] VITE_GOOGLE_MAPS_API_KEY not set, skipping reverse geocode');
+      } else {
+        try {
+          const response = await fetch(
+            `https://maps.googleapis.com/maps/api/geocode/json?latlng=${newPosition.lat},${newPosition.lng}&key=${apiKey}&result_type=neighborhood|sublocality|locality`
+          );
+          const geoData = await response.json();
+          if (geoData.status === 'OK' && geoData.results?.length > 0) {
+            // Find the most descriptive "neighborhood" or "sublocality"
+            const bestMatch = geoData.results.find(r => r.types.includes('neighborhood'))
+                          || geoData.results.find(r => r.types.includes('sublocality'))
+                          || geoData.results[0];
+
+            locationArea = bestMatch.address_components[0].long_name;
+            console.log('[useGPS] 📍 Reverse geocoded area:', locationArea);
+          }
+        } catch (err) {
+          console.warn('[useGPS] Reverse geocoding failed:', err);
         }
-      } catch (err) {
-        console.warn('[useGPS] Reverse geocoding failed:', err);
       }
 
       const locUpdate: Record<string, any> = {


### PR DESCRIPTION
## Summary
- Removes hardcoded fallback Google Maps API key from `src/hooks/useGPS.ts` (the key was exposed in the client bundle).
- Now requires `VITE_GOOGLE_MAPS_API_KEY` env var; logs a warning and skips reverse geocoding gracefully if not set.

## Why
The fallback key `AIzaSyDZBzKf5oO1zhdQph9F5j_1JUihMkFQXM0` was rotated this week (referrer-restricted to hotmessldn.com, billing on, Geocoding API enabled). Leaving the old key in source code is both a credential leak and a footgun — any commit reverting could re-expose it.

## Sweep
\`\`\`
$ grep -rn "AIzaSy" src/ api/
(no hits)
\`\`\`

## Test plan
- [ ] Local dev with VITE_GOOGLE_MAPS_API_KEY set → reverse geocode logs area name as before
- [ ] Local dev with VITE_GOOGLE_MAPS_API_KEY unset → warn logged, no crash, position still tracked