### PR TITLE
fix(sw): bypass service worker for Google Maps API requests

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -3,7 +3,7 @@
  * Handles: Push notifications, caching, offline support, background sync
  */
 
-const CACHE_VERSION = 'v4';
+const CACHE_VERSION = 'v5';
 const STATIC_CACHE = `hotmess-static-${CACHE_VERSION}`;
 const DYNAMIC_CACHE = `hotmess-dynamic-${CACHE_VERSION}`;
 const API_CACHE = `hotmess-api-${CACHE_VERSION}`;
@@ -246,13 +246,20 @@ self.addEventListener('fetch', (event) => {
   // Skip chrome-extension and other non-http requests
   if (!event.request.url.startsWith('http')) return;
   
-  // Skip cross-origin requests that we don't want to cache
   const url = new URL(event.request.url);
+
+  // Bypass SW entirely for Google Maps APIs — referrer-restricted keys need
+  // direct page-context fetches; SW-context fetch strips/modifies Referer,
+  // which makes the API reject the request even with a valid key.
+  if (url.hostname.includes('googleapis')) {
+    return;
+  }
+
+  // Skip cross-origin requests that we don't want to cache
   if (
     url.origin !== self.location.origin &&
     !url.hostname.includes('supabase') &&
-    !url.hostname.includes('cloudinary') &&
-    !url.hostname.includes('googleapis')
+    !url.hostname.includes('cloudinary')
   ) {
     return;
   }


### PR DESCRIPTION
## Summary
- Service worker fetch handler was intercepting `maps.googleapis.com` requests and running them through `networkFirst()`. The SW-context fetch strips/modifies the `Referer` header, which the new referrer-restricted Maps key rejects — every reverse-geocode and Maps tile request failed despite the page being on an allowed origin.
- Early-return for `googleapis` hostname so the browser handles the fetch in page context with the correct `Referer`.
- Bumps `CACHE_VERSION` v4 → v5 to force the new SW to activate on next visit.

## Why this is the actual root cause
Cowork verified this morning:
- Maps API key is rotated, restricted, billing on, Geocoding API enabled
- Direct REST calls return 200 OK
- But the page still logs `[LocationService] Reverse geocode failed`
- Console traces showed the request reaching the SW, then failing inside `networkFirst()`

## Verify after merge + redeploy
1. Hard reload (Cmd+Shift+R) on https://hotmessldn.com/pulse, OR DevTools → Application → Service Workers → Unregister + reload
2. Console should NOT show `[LocationService] Reverse geocode failed`
3. Globe should auto-zoom to user's location within 3 seconds

Reference: `outputs/MAPS_API_KEY_ROTATION.md` for the full key rotation context.

## Test plan
- [ ] Local dev: SW registers cleanly, no console errors
- [ ] Prod: hard reload after deploy → reverse geocode succeeds
- [ ] Prod: city heat map tiles load (if Maps tiles in use)