### PR TITLE
fix(pulse): unpack city heat fetch error for diagnosis

### DIFF
--- a/src/hooks/useGlobeRealtime.ts
+++ b/src/hooks/useGlobeRealtime.ts
@@ -86,7 +86,17 @@ export function useGlobeRealtime() {
       const { data, error } = await supabase
         .from('night_pulse_realtime')
         .select('city_id, city_name, latitude, longitude, active_beacons, heat_intensity, scans_last_hour');
-      if (error) throw error;
+      if (error) {
+        // PostgrestError is a plain object; default %o stringification renders
+        // it as "Object". Unpack the diagnostic fields explicitly.
+        console.warn('[GlobeRealtime] city heat fetch failed:', {
+          message: error.message,
+          code: error.code,
+          details: error.details,
+          hint: error.hint,
+        });
+        return;
+      }
       if (!mountedRef.current) return;
       setCityHeat(
         (data || []).map((c: Record<string, unknown>) => ({
@@ -100,7 +110,10 @@ export function useGlobeRealtime() {
         }))
       );
     } catch (e) {
-      console.warn('[GlobeRealtime] city heat fetch failed:', e);
+      console.warn(
+        '[GlobeRealtime] city heat fetch threw:',
+        e instanceof Error ? `${e.name}: ${e.message}` : JSON.stringify(e)
+      );
     }
   }, []);
 
@@ -116,7 +129,15 @@ export function useGlobeRealtime() {
           'venue_id, ends_at, starts_at, description, owner_id'
         )
         .eq('status', 'active');
-      if (error) throw error;
+      if (error) {
+        console.warn('[GlobeRealtime] beacons fetch failed:', {
+          message: error.message,
+          code: error.code,
+          details: error.details,
+          hint: error.hint,
+        });
+        return;
+      }
       if (!mountedRef.current) return;
 
       const now = new Date();
@@ -146,7 +167,10 @@ export function useGlobeRealtime() {
           }))
       );
     } catch (e) {
-      console.warn('[GlobeRealtime] beacons fetch failed:', e);
+      console.warn(
+        '[GlobeRealtime] beacons fetch threw:',
+        e instanceof Error ? `${e.name}: ${e.message}` : JSON.stringify(e)
+      );
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- The catch block logged \`e\` directly, which Chrome's console renders as \`Object\` when the error is a Supabase \`PostgrestError\` (plain object, not an \`Error\` instance).
- Now unpacks \`message\` / \`code\` / \`details\` / \`hint\` so the actual cause is visible in console without needing to re-trigger and inspect.
- Same fix applied to the beacons fetch path for consistency.

## Why
Cowork verified this morning that \`night_pulse_realtime\` returns 200 OK with 15 cities via direct REST. But the React frontend logs \`[GlobeRealtime] city heat fetch failed: Object\` every poll cycle. With this PR merged + redeployed, the next reproduction will show the real PostgrestError fields so the underlying cause (column mismatch / RLS / shape) can be diagnosed and fixed in a follow-up PR.

## Test plan
- [ ] Local dev with intentionally broken query (e.g. select non-existent column) → console shows actual error message, not \`Object\`
- [ ] Prod after deploy → grab the next \`city heat fetch failed\` log and file the follow-up fix