### PR TITLE
fix(pulse): unify layers state to GlobeContext (C.1)

### DIFF
--- a/src/pages/Globe.jsx
+++ b/src/pages/Globe.jsx
@@ -11,7 +11,6 @@ import CityDataOverlay from '../components/globe/CityDataOverlay';
 import { Layers } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { createPageUrl } from '../utils';
-import { debounce } from 'lodash';
 import ErrorBoundary from '../components/error/ErrorBoundary';
 import { fetchNearbyCandidates } from '@/api/connectProximity';
 import { safeGetViewerLatLng } from '@/utils/geolocation';
@@ -186,20 +185,8 @@ export default function GlobePage({ embedded = false }) {
   // is re-architected (Path B in PULSE_AUDIT_2026_05_08.md). When that lands,
   // re-introduce the channel + state here.
 
-  const [activeLayers, setActiveLayers] = useState(['pins']);
-  const [debouncedLayers, setDebouncedLayers] = useState(['pins']);
   const [activeMode, setActiveMode] = useState(null);
   const [selectedBeacon, setSelectedBeacon] = useState(null);
-
-  // Debounce layer changes to prevent memory leak from rapid toggling
-  const debouncedSetLayers = React.useMemo(
-    () => debounce((layers) => setDebouncedLayers(layers), 300),
-    []
-  );
-
-  useEffect(() => {
-    debouncedSetLayers(activeLayers);
-  }, [activeLayers, debouncedSetLayers]);
   const [beaconType, setBeaconType] = useState(null);
   const [minIntensity, setMinIntensity] = useState(0);
   const [recencyFilter, setRecencyFilter] = useState('all');
@@ -251,7 +238,7 @@ export default function GlobePage({ embedded = false }) {
   const liveBeaconCount = realtimeBeacons?.length ?? 0;
   const globeActivity = useGlobeActivity(liveBeaconCount);
 
-  const showPeoplePins = activeLayers.includes('people');
+  const showPeoplePins = activeLayer.people;
 
   const { data: nearbyResponse } = useQuery({
     queryKey: ['globe-nearby', userLocation?.lat, userLocation?.lng],
@@ -600,7 +587,6 @@ export default function GlobePage({ embedded = false }) {
 
             venueIntensity={venueIntensity}
             venueVibes={venueVibes}
-            activeLayers={debouncedLayers}
             userIntents={userIntents}
             routesData={realtimeRoutes}
             globeActivity={globeActivity}


### PR DESCRIPTION
## Summary
Removes dead component-level layer state from \`src/pages/Globe.jsx\`:
- \`activeLayers\` was initialized to \`['pins']\` and never updated via its setter
- \`debouncedLayers\` + \`debouncedSetLayers\` debouncer ran on every render even though the input never changed
- The \`activeLayers\` prop was passed to \`EnhancedGlobe3D\`, which never declared or consumed it

\`showPeoplePins\` now derives from \`activeLayer.people\` in \`GlobeContext\` — the same context that \`LayersSheet\` already mutates. Single source of truth for all 6 layer toggles (events, venues, people, safety, market, radio).

Also drops the now-unused \`lodash/debounce\` import.

## Why
First of 4 Pulse P1 fixes — establishes the unified layer model that C.2 (filter consistency) depends on.

## Test plan
- [ ] Toggle each layer in LayersSheet → only the toggled category disappears/reappears
- [ ] People layer toggle → activity pins show/hide correctly
- [ ] No console warnings about unknown props on EnhancedGlobe3D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized layer-toggling logic to derive state directly from context instead of maintaining local state, improving efficiency while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->