### PR TITLE
fix(pulse): layer filter consistency across all 6 categories (C.2)

### DIFF
--- a/src/pages/Globe.jsx
+++ b/src/pages/Globe.jsx
@@ -402,12 +402,22 @@ export default function GlobePage({ embedded = false }) {
       }
     }
 
-    // Layer filtering from GlobeContext
-    if (!activeLayer.events)  filtered = filtered.filter(b => b.type !== 'event'  && b.kind !== 'event');
-    if (!activeLayer.venues)  filtered = filtered.filter(b => b.beacon_category !== 'venue');
-    if (!activeLayer.people)  filtered = filtered.filter(b => b.kind !== 'person');
-    if (!activeLayer.safety)  filtered = filtered.filter(b => b.type !== 'safety' && b.kind !== 'safety');
-    if (!activeLayer.market)  filtered = filtered.filter(b => b.type !== 'market' && b.kind !== 'market');
+    // Layer filtering from GlobeContext.
+    // Each category matches on EITHER beacon_category (canonical, from the
+    // beacons table) OR type/kind (legacy fields still present on some
+    // realtime payloads). Keep all 6 categories in sync with LAYER_DEFS.
+    const matches = (b, ...needles) => {
+      const cat = String(b.beacon_category || '').toLowerCase();
+      const type = String(b.type || '').toLowerCase();
+      const kind = String(b.kind || '').toLowerCase();
+      return needles.some(n => cat === n || type === n || kind === n);
+    };
+    if (!activeLayer.events) filtered = filtered.filter(b => !matches(b, 'event'));
+    if (!activeLayer.venues) filtered = filtered.filter(b => !matches(b, 'venue'));
+    if (!activeLayer.people) filtered = filtered.filter(b => !matches(b, 'person', 'user'));
+    if (!activeLayer.safety) filtered = filtered.filter(b => !matches(b, 'safety'));
+    if (!activeLayer.market) filtered = filtered.filter(b => !matches(b, 'market', 'vendor'));
+    if (!activeLayer.radio)  filtered = filtered.filter(b => !matches(b, 'radio'));
 
     return filtered;
   }, [realtimeBeacons, activeMode, beaconType, minIntensity, recencyFilter, searchResults, radiusSearch, nearbyPeoplePins, showPeoplePins, realtimeLocations, activeLayer]);


### PR DESCRIPTION
## Summary
\`LayersSheet\` exposes 6 toggles (events / venues / people / safety / market / radio) but the filter logic in \`filteredBeacons\` only honoured 5 — radio was UI-only. Each category also matched on a different combination of \`beacon_category\` vs \`type\` vs \`kind\`, leading to subtle inconsistencies for beacons that carry multiple fields.

Now uses a single \`matches(b, ...needles)\` helper that checks all three fields. Adds:
- **radio** filter (was missing entirely — toggle did nothing)
- **user** as a synonym for **person** on the people layer (matches the \`beacon_category\` enum from \`useGlobeRealtime.ts\`)
- **vendor** as a synonym for **market** (matches the beacon \`type\` enum)

## Why
Second of 4 Pulse P1 fixes. Builds on C.1 (#248) which unified the layer state in GlobeContext.

## Test plan
- [ ] Toggle Radio off → radio beacons disappear from globe
- [ ] Toggle People off → both \`kind: 'person'\` and \`beacon_category: 'user'\` pins disappear
- [ ] Toggle Market off → both \`type: 'market'\` and \`type: 'vendor'\` pins disappear
- [ ] All other layer toggles continue to work as before