### PR TITLE
fix(pulse): user beacon View Profile CTA in preview panel (C.4)

### DIFF
--- a/src/components/globe/BeaconPreviewPanel.jsx
+++ b/src/components/globe/BeaconPreviewPanel.jsx
@@ -2,15 +2,19 @@ import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 
-import { X, MapPin, HeartHandshake } from 'lucide-react';
+import { X, MapPin, HeartHandshake, UserCircle2 } from 'lucide-react';
 import { createPageUrl } from '../../utils';
 
-export default function BeaconPreviewPanel({ beacon, onClose, onViewFull }) {
+export default function BeaconPreviewPanel({ beacon, onClose, onViewFull, onViewProfile }) {
   const navigate = useNavigate();
   if (!beacon) return null;
 
   const isPerson = beacon.kind === 'person';
   const isRecovery = beacon.kind === 'recovery' || beacon.beacon_category === 'recovery';
+  const isUserBeacon =
+    isPerson ||
+    beacon.beacon_category === 'user' ||
+    Boolean(beacon.user_id || beacon.owner_id);
   const detailsUrl = isPerson && beacon.email
     ? createPageUrl(`Profile?email=${encodeURIComponent(beacon.email)}`)
     : createPageUrl('BeaconDetail') + '?id=' + encodeURIComponent(beacon.id);
@@ -124,6 +128,16 @@ export default function BeaconPreviewPanel({ beacon, onClose, onViewFull }) {
               >
                 <HeartHandshake className="w-4 h-4" />
                 Open Hand N Hand
+              </button>
+            )}
+
+            {!isRecovery && isUserBeacon && onViewProfile && (
+              <button
+                onClick={() => onViewProfile(beacon)}
+                className="w-full mt-2 py-3.5 bg-[#C8962C] text-black rounded-xl font-black uppercase tracking-widest text-xs flex items-center justify-center gap-2"
+              >
+                <UserCircle2 className="w-4 h-4" />
+                View Profile
               </button>
             )}
           </div>

--- a/src/pages/Globe.jsx
+++ b/src/pages/Globe.jsx
@@ -697,6 +697,17 @@ export default function GlobePage({ embedded = false }) {
             beacon={previewBeacon}
             onClose={() => setPreviewBeacon(null)}
             onViewFull={handleViewFullDetails}
+            onViewProfile={(b) => {
+              const userId = b.user_id || b.owner_id || b.id;
+              if (!userId) return;
+              setPreviewBeacon(null);
+              openProfile({
+                userId,
+                source: 'globe',
+                email: b.email,
+                preferSheet: true,
+              });
+            }}
           />
         )}
 


### PR DESCRIPTION
## Summary
When a user/person beacon opens in \`BeaconPreviewPanel\` there was no way to navigate from the preview to the actual profile sheet — users saw the beacon title, location, badges, and dead-ended.

Adds a gold **View Profile** CTA at the bottom of the panel when the beacon is identifiable as a user:
- \`beacon.kind === 'person'\`, OR
- \`beacon.beacon_category === 'user'\`, OR
- \`beacon.user_id\` or \`beacon.owner_id\` is set

The CTA closes the preview and calls \`openProfile()\` with the resolved \`userId\`, \`source='globe'\`, and \`preferSheet=true\` — the Profile Authority contract (opens \`L2ProfileSheet\` instead of routing).

Also cleans out the unused \`kindColors\` / \`color\` constants from the panel while touching it.

## Why
Last of 4 Pulse P1 fixes. Closes a dead-end UX path for user beacons.

## Test plan
- [ ] Tap a person pin (with email) → already opens profile directly (existing behavior, unchanged)
- [ ] Tap a user beacon WITHOUT email but WITH \`owner_id\` → preview opens; CTA visible; tap → profile sheet opens
- [ ] Tap a venue/event/recovery → CTA NOT shown
- [ ] Tap a beacon with no user identity at all → CTA NOT shown