### PR TITLE
fix(pulse): widen mobile tap targets on globe pins (G)

### DIFF
--- a/src/components/globe/EnhancedGlobe3D.jsx
+++ b/src/components/globe/EnhancedGlobe3D.jsx
@@ -17,18 +17,23 @@ export default function EnhancedGlobe3D({
   console.log('[Globe] Recovery Pins:', recoveryPins?.length || 0);
 
 
+  // Pin sizes — tuned 2026-05-09 for mobile tap targets.
+  // Recovery is the largest because it's the lowest-density layer and the
+  // safest to overdraw. Person pins were noticeably under tap-radius before.
+  const PIN_SIZE = { person: 0.55, recovery: 1.0, default: 0.7 };
+
   // Optimized data for the globe
   const pointsData = useMemo(() => {
     const beaconPoints = beacons.map(b => {
       const lat = Number(b.lat ?? b.location_lat);
       const lng = Number(b.lng ?? b.location_lng);
       if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
-      
+
       return {
         ...b,
         lat,
         lng,
-        size: b.kind === 'person' ? 0.4 : 0.6,
+        size: b.kind === 'person' ? PIN_SIZE.person : PIN_SIZE.default,
         color: b.kind === 'person' ? '#00C2E0' : '#FFEB3B'
       };
     }).filter(Boolean);
@@ -42,7 +47,7 @@ export default function EnhancedGlobe3D({
         ...r,
         lat,
         lng,
-        size: 0.8,
+        size: PIN_SIZE.recovery,
         color: '#FFFFFF', // Pure White for Recovery
         isRecovery: true
       };
@@ -115,7 +120,7 @@ export default function EnhancedGlobe3D({
         pointLng="lng"
         pointColor="color"
         pointRadius="size"
-        pointAltitude={0.05} // Raised higher to ensure easy clicking on mobile
+        pointAltitude={0.07} // Raised slightly higher 2026-05-09 to widen mobile tap target
         onPointClick={(point) => {
           console.log('[Globe] Point clicked:', point);
           // Subtle zoom-in to make the click feel responsive


### PR DESCRIPTION
## Summary
Pin radii in \`EnhancedGlobe3D\` were tuned for desktop hover; on mobile they were noticeably under-thumb. Bumps the four sizing constants and pulls them into a named map for clarity.

| Pin | Before | After |
|---|---|---|
| person | 0.40 | 0.55 |
| recovery | 0.80 | 1.00 |
| default beacon | 0.60 | 0.70 |
| \`pointAltitude\` | 0.05 | 0.07 |

Recovery is the largest because it's the lowest-density layer and the safest to overdraw.

## Wave G scope notes
This PR addresses one of three Wave G items. The other two are intentionally **not** included:

- **Marquee ticker** — \`GlobalTicker\` already animates correctly with hover-pause and a 30s loop. No issue found that warranted a code change without product input.
- **Persona-tinted atmosphere** — The Globe atmosphere is currently \`#00C2E0\` (radio teal). Tinting per active persona is an editorial design call (which colour family per persona, intensity, fallback when no persona is active). Deferred for a Phil pass.

## Test plan
- [ ] Tap a person pin on mobile — should hit cleanly first try
- [ ] Tap a recovery pin (white) on mobile — visibly larger; tap target still feels intentional
- [ ] Pins don't visibly bleed into each other in dense city centers