### PR TITLE
feat(onboarding): Pulse-first destination after auth (Grindr-fast directive)

### DIFF
--- a/src/components/onboarding/First5MinutesFlow.jsx
+++ b/src/components/onboarding/First5MinutesFlow.jsx
@@ -11,7 +11,7 @@ import { useFirst5Minutes, F5M_STAGES } from '@/hooks/useFirst5Minutes';
  * 9 screens: Cold Open → Auth → Age → Name → Sound → Ghosted → Match → Chat → Arrival
  * Each stage: logged to analytics_events + persisted to profiles.onboarding_stage
  * Resume: mounts at correct stage from profile
- * Complete: onboarding_stage → 'complete', navigate → /ghosted
+ * Complete: onboarding_stage → 'complete', navigate → /pulse
  */
 
 const T = {
@@ -366,7 +366,7 @@ export default function First5MinutesFlow({ initialStage, onComplete }) {
   const handleDone = async () => {
     await completeOnboarding();
     onComplete?.();
-    navigate('/ghosted');
+    navigate('/pulse');
   };
 
   const screens = [

--- a/src/components/onboarding/OnboardingRouter.jsx
+++ b/src/components/onboarding/OnboardingRouter.jsx
@@ -5,7 +5,7 @@
  * and NEEDS_COMMUNITY_GATE states.
  *
  * Active flow (as of 2026-05-09 — Grindr-fast directive):
- *   Splash → AgeGate → SignUp (auth) → QuickSetup → /ghosted
+ *   Splash → AgeGate → SignUp (auth) → QuickSetup → /pulse
  *
  * Both ProfileScreen (vibe/orientation/body/height/ethnicity) and
  * PinSetupScreen are removed from the gate. Vibe data lives in
@@ -17,8 +17,8 @@
  *   null / start / age_gate → AgeGateScreen (or SignUpScreen if sessionStorage age passed)
  *   age_verified / signup / profile / vibe / safety / location → QuickSetupScreen
  *   signed_up → QuickSetupScreen
- *   quick_setup / profile_complete / vibe_complete / pin_complete → /ghosted
- *   complete → /ghosted (BootRouter intercepts, never reaches here)
+ *   quick_setup / profile_complete / vibe_complete / pin_complete → /pulse
+ *   complete → /pulse (BootRouter intercepts, never reaches here)
  */
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useV6Flag as useFlag } from '@/hooks/useV6Flag';
@@ -147,7 +147,7 @@ export default function OnboardingRouter() {
 
     // Already complete?
     if (freshProfile.onboarding_completed) {
-      navigate('/ghosted', { replace: true });
+      navigate('/pulse', { replace: true });
       return;
     }
 
@@ -321,7 +321,7 @@ export default function OnboardingRouter() {
     if (refetchProfile) {
       await refetchProfile();
     }
-    navigate('/ghosted', { replace: true });
+    navigate('/pulse', { replace: true });
   }, [navigate, refetchProfile]);
 
   // v6 F5M — render intercept (all hooks above, safe to return here)

--- a/src/pages/auth/callback.jsx
+++ b/src/pages/auth/callback.jsx
@@ -7,12 +7,13 @@ import logger from '@/utils/logger';
  * OAuth / Magic Link Callback Handler
  *
  * After Supabase verifies the token:
- * - Returning user (onboarding_completed = true) → /ghosted
+ * - Returning user (onboarding_completed = true) → /pulse
  * - New / incomplete user → /
  * - Bot/scraper hitting a stale link (400 error) → / gracefully
  *
- * The BootGuardContext will handle final routing from / anyway,
- * so /ghosted for returning users is an optimistic fast-path.
+ * The BootGuardContext will handle final routing from / anyway, so /pulse
+ * for returning users is an optimistic fast-path. Pulse is the primary
+ * destination per the Grindr-fast directive (2026-05-09).
  */
 export default function AuthCallback() {
   const navigate = useNavigate();
@@ -69,9 +70,9 @@ export default function AuthCallback() {
               await routeAfterAuth(existing.session.user.id, navigate);
               return;
             }
-            // No session at all — redirect to /ghosted as a best-effort
+            // No session at all — redirect to /pulse as a best-effort
             // (BootGuardContext will redirect to auth if truly unauthenticated)
-            navigate('/ghosted', { replace: true });
+            navigate('/pulse', { replace: true });
             return;
           }
 
@@ -162,7 +163,7 @@ export default function AuthCallback() {
 
 /**
  * After a successful auth, check onboarding_completed and route accordingly.
- * Returning user → /ghosted. New/incomplete user → /.
+ * Returning user → /pulse. New/incomplete user → /.
  * Also handles referral code capture for new users.
  */
 async function routeAfterAuth(userId, navigate) {
@@ -189,7 +190,7 @@ async function routeAfterAuth(userId, navigate) {
       }
     } catch {}
 
-    const dest = profile?.onboarding_completed === true ? '/ghosted' : '/';
+    const dest = profile?.onboarding_completed === true ? '/pulse' : '/';
     navigate(dest, { replace: true });
     // Hard fallback: if React Router navigate doesn't fire (race with BootGuard),
     // force a full page load after a short delay.


### PR DESCRIPTION
## Summary
Returning users and onboarding-complete users are now routed to \`/pulse\` instead of \`/ghosted\`. Per the Grindr-fast directive, the live Pulse globe is the primary entry point — users land where the action is, not where the grid is.

## Changes (4 navigate calls + 3 docstrings)
- \`src/pages/auth/callback.jsx\`: \`routeAfterAuth\` dest, the bot/expired-code fallback, and the docstring
- \`src/components/onboarding/OnboardingRouter.jsx\`: \`handlePinComplete\` final navigate, the "already complete" fast-path navigate, plus docstring
- \`src/components/onboarding/First5MinutesFlow.jsx\`: completion navigate + docstring

\`/ghosted\` remains fully accessible via the bottom nav — it's just no longer the default landing target.

## Test plan
- [ ] Sign in with completed onboarding → land on /pulse, not /ghosted
- [ ] OAuth callback → /pulse on success
- [ ] OAuth bot/expired-code path → /pulse fallback
- [ ] First5MinutesFlow completion → /pulse
- [ ] Direct \`/ghosted\` link still works

## Wave F · 3 of 3 onboarding-defer PRs
- F1 #254 defer profile name/photo
- F2 #255 defer vibe (drop ProfileScreen)
- **F3 (this)** Pulse-first destination

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated post-onboarding and authentication redirect destination for a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->