### PR TITLE
feat(auth): phone OTP via Twilio Verify

### DIFF
--- a/api/auth/phone-otp-send.js
+++ b/api/auth/phone-otp-send.js
@@ -5,9 +5,14 @@
  * Body: { phone: '+447700900123' }  (E.164)
  *
  * Env required:
- *   TWILIO_ACCOUNT_SID
- *   TWILIO_AUTH_TOKEN
- *   TWILIO_VERIFY_SERVICE_SID  (Verify service "Service SID")
+ *   TWILIO_ACCOUNT_SID         (already in Vercel for SMS)
+ *   TWILIO_API_KEY_SID         (rotatable API Key, starts with 'SK…')
+ *   TWILIO_API_KEY_SECRET      (rotatable API Key secret)
+ *   TWILIO_VERIFY_SERVICE_SID  (Verify service "Service SID" — Phil
+ *                               provisions this in Twilio Console)
+ *
+ * Twilio Basic auth uses API Key SID:API Key Secret. Falls back to
+ * AccountSid:AuthToken if API Key creds aren't set, for migration safety.
  *
  * Twilio Verify docs: https://www.twilio.com/docs/verify/api/verification
  *
@@ -17,19 +22,36 @@
 
 const E164_RE = /^\+[1-9]\d{6,14}$/;
 
+function getTwilioBasicAuth() {
+  const apiKeySid = process.env.TWILIO_API_KEY_SID;
+  const apiKeySecret = process.env.TWILIO_API_KEY_SECRET;
+  const accountSid = process.env.TWILIO_ACCOUNT_SID;
+  const authToken = process.env.TWILIO_AUTH_TOKEN;
+
+  // Prefer API Key creds (rotatable). Fall back to Account SID + Auth Token.
+  if (apiKeySid && apiKeySecret) {
+    return Buffer.from(`${apiKeySid}:${apiKeySecret}`).toString('base64');
+  }
+  if (accountSid && authToken) {
+    return Buffer.from(`${accountSid}:${authToken}`).toString('base64');
+  }
+  return null;
+}
+
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  const accountSid = process.env.TWILIO_ACCOUNT_SID;
-  const authToken = process.env.TWILIO_AUTH_TOKEN;
+  const basicAuth = getTwilioBasicAuth();
   const serviceSid = process.env.TWILIO_VERIFY_SERVICE_SID;
 
-  if (!accountSid || !authToken || !serviceSid) {
-    return res.status(500).json({
-      error: 'MISSING_TWILIO_VERIFY_SID',
-      detail: 'Set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, and TWILIO_VERIFY_SERVICE_SID in env to enable phone OTP.',
+  if (!basicAuth || !serviceSid) {
+    return res.status(503).json({
+      error: 'TWILIO_VERIFY_SERVICE_SID not configured',
+      detail:
+        'Set TWILIO_API_KEY_SID + TWILIO_API_KEY_SECRET (preferred) or ' +
+        'TWILIO_ACCOUNT_SID + TWILIO_AUTH_TOKEN, plus TWILIO_VERIFY_SERVICE_SID.',
     });
   }
 
@@ -41,11 +63,10 @@ export default async function handler(req, res) {
   try {
     const url = `https://verify.twilio.com/v2/Services/${encodeURIComponent(serviceSid)}/Verifications`;
     const body = new URLSearchParams({ To: phone, Channel: 'sms' });
-    const auth = Buffer.from(`${accountSid}:${authToken}`).toString('base64');
     const r = await fetch(url, {
       method: 'POST',
       headers: {
-        'Authorization': `Basic ${auth}`,
+        'Authorization': `Basic ${basicAuth}`,
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       body,

--- a/api/auth/phone-otp-send.js
+++ b/api/auth/phone-otp-send.js
@@ -1,0 +1,68 @@
+/**
+ * POST /api/auth/phone-otp-send
+ *
+ * Sends an OTP via Twilio Verify to the supplied phone number.
+ * Body: { phone: '+447700900123' }  (E.164)
+ *
+ * Env required:
+ *   TWILIO_ACCOUNT_SID
+ *   TWILIO_AUTH_TOKEN
+ *   TWILIO_VERIFY_SERVICE_SID  (Verify service "Service SID")
+ *
+ * Twilio Verify docs: https://www.twilio.com/docs/verify/api/verification
+ *
+ * Frontend should pre-validate phone to E.164 (use react-phone-number-input).
+ * This endpoint trusts the validation but still rejects obviously bad input.
+ */
+
+const E164_RE = /^\+[1-9]\d{6,14}$/;
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const accountSid = process.env.TWILIO_ACCOUNT_SID;
+  const authToken = process.env.TWILIO_AUTH_TOKEN;
+  const serviceSid = process.env.TWILIO_VERIFY_SERVICE_SID;
+
+  if (!accountSid || !authToken || !serviceSid) {
+    return res.status(500).json({
+      error: 'MISSING_TWILIO_VERIFY_SID',
+      detail: 'Set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, and TWILIO_VERIFY_SERVICE_SID in env to enable phone OTP.',
+    });
+  }
+
+  const phone = String(req.body?.phone || '').trim();
+  if (!E164_RE.test(phone)) {
+    return res.status(400).json({ error: 'Invalid phone number — must be E.164 (e.g. +447700900123)' });
+  }
+
+  try {
+    const url = `https://verify.twilio.com/v2/Services/${encodeURIComponent(serviceSid)}/Verifications`;
+    const body = new URLSearchParams({ To: phone, Channel: 'sms' });
+    const auth = Buffer.from(`${accountSid}:${authToken}`).toString('base64');
+    const r = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Basic ${auth}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body,
+    });
+    const data = await r.json().catch(() => ({}));
+    if (!r.ok) {
+      return res.status(r.status).json({
+        error: data?.message || 'Twilio Verify send failed',
+        code: data?.code,
+      });
+    }
+    return res.status(200).json({
+      ok: true,
+      sid: data?.sid,
+      status: data?.status,
+    });
+  } catch (e) {
+    return res.status(500).json({ error: 'Internal error', detail: e.message });
+  }
+}

--- a/api/auth/phone-otp-verify.js
+++ b/api/auth/phone-otp-verify.js
@@ -1,0 +1,155 @@
+/**
+ * POST /api/auth/phone-otp-verify
+ *
+ * Verifies a Twilio Verify OTP code, then creates / fetches a Supabase user
+ * keyed by phone and returns a session for the client to setSession() with.
+ *
+ * Body: { phone: '+447700900123', code: '123456' }
+ *
+ * Env required:
+ *   TWILIO_ACCOUNT_SID
+ *   TWILIO_AUTH_TOKEN
+ *   TWILIO_VERIFY_SERVICE_SID
+ *   SUPABASE_URL
+ *   SUPABASE_SERVICE_ROLE_KEY
+ *
+ * Returns:
+ *   200 { user_id, action_link } — frontend opens action_link to redeem session
+ *   400 { error: 'invalid_code' | 'invalid_phone' }
+ *   500 { error: 'MISSING_TWILIO_VERIFY_SID' | 'SUPABASE_ADMIN_NOT_CONFIGURED' | … }
+ *
+ * Why action_link instead of access_token: minting a Supabase-compatible JWT
+ * needs SUPABASE_JWT_SECRET + manual signing. generateLink('magiclink') is
+ * server-side-only too but uses Supabase's own minting machinery and is
+ * already supported in @supabase/supabase-js admin client.
+ */
+
+import { supabaseAdmin } from '../_utils/supabaseAdmin.js';
+
+const E164_RE = /^\+[1-9]\d{6,14}$/;
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const accountSid = process.env.TWILIO_ACCOUNT_SID;
+  const authToken = process.env.TWILIO_AUTH_TOKEN;
+  const serviceSid = process.env.TWILIO_VERIFY_SERVICE_SID;
+
+  if (!accountSid || !authToken || !serviceSid) {
+    return res.status(500).json({
+      error: 'MISSING_TWILIO_VERIFY_SID',
+      detail: 'Set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_VERIFY_SERVICE_SID in env.',
+    });
+  }
+
+  const phone = String(req.body?.phone || '').trim();
+  const code = String(req.body?.code || '').trim();
+
+  if (!E164_RE.test(phone)) {
+    return res.status(400).json({ error: 'invalid_phone' });
+  }
+  if (!/^\d{4,8}$/.test(code)) {
+    return res.status(400).json({ error: 'invalid_code_format' });
+  }
+
+  // Step 1: Verify the OTP with Twilio Verify
+  try {
+    const url = `https://verify.twilio.com/v2/Services/${encodeURIComponent(serviceSid)}/VerificationCheck`;
+    const body = new URLSearchParams({ To: phone, Code: code });
+    const auth = Buffer.from(`${accountSid}:${authToken}`).toString('base64');
+    const r = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Basic ${auth}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body,
+    });
+    const data = await r.json().catch(() => ({}));
+    if (!r.ok) {
+      return res.status(r.status).json({
+        error: data?.message || 'Twilio verify check failed',
+        code: data?.code,
+      });
+    }
+    if (data?.status !== 'approved') {
+      return res.status(400).json({ error: 'invalid_code', status: data?.status });
+    }
+  } catch (e) {
+    return res.status(502).json({ error: 'twilio_unreachable', detail: e.message });
+  }
+
+  // Step 2: upsert Supabase user by phone, get/issue a magiclink action_link
+  let admin;
+  try {
+    admin = supabaseAdmin();
+  } catch (e) {
+    return res.status(500).json({
+      error: 'SUPABASE_ADMIN_NOT_CONFIGURED',
+      detail: e.message,
+    });
+  }
+
+  try {
+    // listUsers can't filter by phone directly; use a synthetic email keyed
+    // by phone so generateLink('magiclink') works. The phone is also stored
+    // on the user for canonical identity.
+    const syntheticEmail = `${phone.replace(/[^0-9]/g, '')}@hotmess.phone`;
+
+    // Find or create the user
+    let userId = null;
+    const { data: existing } = await admin.auth.admin.listUsers({ page: 1, perPage: 200 });
+    const match = existing?.users?.find(
+      (u) => u.phone === phone.replace(/^\+/, '') || u.email === syntheticEmail,
+    );
+    if (match) {
+      userId = match.id;
+    } else {
+      const { data: created, error: createErr } = await admin.auth.admin.createUser({
+        phone: phone.replace(/^\+/, ''),
+        phone_confirm: true,
+        email: syntheticEmail,
+        email_confirm: true,
+        user_metadata: { auth_method: 'phone_otp', phone_e164: phone },
+      });
+      if (createErr || !created?.user?.id) {
+        return res.status(500).json({
+          error: 'supabase_create_user_failed',
+          detail: createErr?.message,
+        });
+      }
+      userId = created.user.id;
+    }
+
+    // Generate a one-time magiclink for the synthetic email
+    const { data: linkData, error: linkErr } = await admin.auth.admin.generateLink({
+      type: 'magiclink',
+      email: syntheticEmail,
+      options: {
+        redirectTo: `${getOrigin(req)}/auth/callback`,
+      },
+    });
+    if (linkErr || !linkData?.properties?.action_link) {
+      return res.status(500).json({
+        error: 'supabase_generate_link_failed',
+        detail: linkErr?.message,
+      });
+    }
+
+    return res.status(200).json({
+      ok: true,
+      user_id: userId,
+      action_link: linkData.properties.action_link,
+    });
+  } catch (e) {
+    return res.status(500).json({ error: 'internal_error', detail: e.message });
+  }
+}
+
+function getOrigin(req) {
+  const proto = req.headers?.['x-forwarded-proto'] || 'https';
+  const host = req.headers?.host || 'hotmessldn.com';
+  return `${proto}://${host}`;
+}

--- a/api/auth/phone-otp-verify.js
+++ b/api/auth/phone-otp-verify.js
@@ -28,19 +28,35 @@ import { supabaseAdmin } from '../_utils/supabaseAdmin.js';
 
 const E164_RE = /^\+[1-9]\d{6,14}$/;
 
+function getTwilioBasicAuth() {
+  const apiKeySid = process.env.TWILIO_API_KEY_SID;
+  const apiKeySecret = process.env.TWILIO_API_KEY_SECRET;
+  const accountSid = process.env.TWILIO_ACCOUNT_SID;
+  const authToken = process.env.TWILIO_AUTH_TOKEN;
+
+  if (apiKeySid && apiKeySecret) {
+    return Buffer.from(`${apiKeySid}:${apiKeySecret}`).toString('base64');
+  }
+  if (accountSid && authToken) {
+    return Buffer.from(`${accountSid}:${authToken}`).toString('base64');
+  }
+  return null;
+}
+
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  const accountSid = process.env.TWILIO_ACCOUNT_SID;
-  const authToken = process.env.TWILIO_AUTH_TOKEN;
+  const basicAuth = getTwilioBasicAuth();
   const serviceSid = process.env.TWILIO_VERIFY_SERVICE_SID;
 
-  if (!accountSid || !authToken || !serviceSid) {
-    return res.status(500).json({
-      error: 'MISSING_TWILIO_VERIFY_SID',
-      detail: 'Set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_VERIFY_SERVICE_SID in env.',
+  if (!basicAuth || !serviceSid) {
+    return res.status(503).json({
+      error: 'TWILIO_VERIFY_SERVICE_SID not configured',
+      detail:
+        'Set TWILIO_API_KEY_SID + TWILIO_API_KEY_SECRET (preferred) or ' +
+        'TWILIO_ACCOUNT_SID + TWILIO_AUTH_TOKEN, plus TWILIO_VERIFY_SERVICE_SID.',
     });
   }
 
@@ -58,11 +74,10 @@ export default async function handler(req, res) {
   try {
     const url = `https://verify.twilio.com/v2/Services/${encodeURIComponent(serviceSid)}/VerificationCheck`;
     const body = new URLSearchParams({ To: phone, Code: code });
-    const auth = Buffer.from(`${accountSid}:${authToken}`).toString('base64');
     const r = await fetch(url, {
       method: 'POST',
       headers: {
-        'Authorization': `Basic ${auth}`,
+        'Authorization': `Basic ${basicAuth}`,
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       body,

--- a/src/components/onboarding/PhoneOtpButton.jsx
+++ b/src/components/onboarding/PhoneOtpButton.jsx
@@ -57,7 +57,8 @@ export default function PhoneOtpButton({ disabled }) {
       });
       const data = await r.json();
       if (!r.ok) {
-        if (data?.error === 'MISSING_TWILIO_VERIFY_SID') {
+        if (data?.error === 'TWILIO_VERIFY_SERVICE_SID not configured' ||
+            data?.error === 'MISSING_TWILIO_VERIFY_SID') {
           setError("Phone sign-in isn't set up yet. Try Apple, Google, or email.");
         } else {
           setError(data?.error || 'Could not send code. Try again.');
@@ -91,7 +92,8 @@ export default function PhoneOtpButton({ disabled }) {
       if (!r.ok) {
         if (data?.error === 'invalid_code') {
           setError("That code didn't match. Try again.");
-        } else if (data?.error === 'MISSING_TWILIO_VERIFY_SID') {
+        } else if (data?.error === 'TWILIO_VERIFY_SERVICE_SID not configured' ||
+                   data?.error === 'MISSING_TWILIO_VERIFY_SID') {
           setError("Phone sign-in isn't set up yet.");
         } else if (data?.error === 'SUPABASE_ADMIN_NOT_CONFIGURED') {
           setError("Server isn't configured to sign you in by phone yet.");

--- a/src/components/onboarding/PhoneOtpButton.jsx
+++ b/src/components/onboarding/PhoneOtpButton.jsx
@@ -1,0 +1,227 @@
+/**
+ * PhoneOtpButton — drop-in "Continue with phone" button for SignUpScreen.
+ *
+ * Flow:
+ *   1. Tap button → inline overlay with E.164 phone input
+ *   2. Submit → POST /api/auth/phone-otp-send (Twilio Verify)
+ *   3. Show 6-digit code input
+ *   4. Submit code → POST /api/auth/phone-otp-verify
+ *   5. On success: assign window.location to the returned action_link
+ *      (Supabase magiclink that lands on /auth/callback with a session)
+ *
+ * Inline E.164 input (no react-phone-number-input dep yet — follow-up PR
+ * can swap in proper country-aware formatting). Validates with regex.
+ *
+ * Errors surfaced cleanly:
+ *   - MISSING_TWILIO_VERIFY_SID → "Phone sign-in isn't set up yet"
+ *   - invalid_code → "That code didn't match"
+ *   - twilio_unreachable → "Couldn't reach SMS provider"
+ */
+import React, { useState } from 'react';
+import { Loader2, Phone, X } from 'lucide-react';
+import { track } from '@/lib/analytics';
+
+const GOLD = '#C8962C';
+const E164_RE = /^\+[1-9]\d{6,14}$/;
+
+export default function PhoneOtpButton({ disabled }) {
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState('phone'); // 'phone' | 'code'
+  const [phone, setPhone] = useState('+44');
+  const [code, setCode] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const reset = () => {
+    setOpen(false);
+    setStep('phone');
+    setPhone('+44');
+    setCode('');
+    setError('');
+    setLoading(false);
+  };
+
+  const sendCode = async (e) => {
+    e?.preventDefault?.();
+    setError('');
+    if (!E164_RE.test(phone)) {
+      setError('Use international format, e.g. +447700900123');
+      return;
+    }
+    setLoading(true);
+    try {
+      const r = await fetch('/api/auth/phone-otp-send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ phone }),
+      });
+      const data = await r.json();
+      if (!r.ok) {
+        if (data?.error === 'MISSING_TWILIO_VERIFY_SID') {
+          setError("Phone sign-in isn't set up yet. Try Apple, Google, or email.");
+        } else {
+          setError(data?.error || 'Could not send code. Try again.');
+        }
+        return;
+      }
+      track('signup', 'onboarding', 'phone_otp_sent');
+      setStep('code');
+    } catch (err) {
+      setError(err?.message || 'Network error. Check connection.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const verifyCode = async (e) => {
+    e?.preventDefault?.();
+    setError('');
+    if (!/^\d{4,8}$/.test(code)) {
+      setError('Enter the 6-digit code');
+      return;
+    }
+    setLoading(true);
+    try {
+      const r = await fetch('/api/auth/phone-otp-verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ phone, code }),
+      });
+      const data = await r.json();
+      if (!r.ok) {
+        if (data?.error === 'invalid_code') {
+          setError("That code didn't match. Try again.");
+        } else if (data?.error === 'MISSING_TWILIO_VERIFY_SID') {
+          setError("Phone sign-in isn't set up yet.");
+        } else if (data?.error === 'SUPABASE_ADMIN_NOT_CONFIGURED') {
+          setError("Server isn't configured to sign you in by phone yet.");
+        } else if (data?.error === 'twilio_unreachable') {
+          setError("Couldn't reach SMS provider. Try again.");
+        } else {
+          setError(data?.error || 'Verification failed. Try again.');
+        }
+        return;
+      }
+      track('signup', 'onboarding', 'phone_otp_verified');
+      // The action_link is a Supabase magiclink that lands on /auth/callback
+      // with a fresh session. Hard-navigate so Supabase processes the hash.
+      if (data?.action_link) {
+        window.location.assign(data.action_link);
+      } else {
+        setError('Sign-in succeeded but no session link. Reload the page.');
+      }
+    } catch (err) {
+      setError(err?.message || 'Network error. Check connection.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        disabled={disabled}
+        className="w-full py-4 rounded-xl bg-white/5 border border-white/10 text-white font-bold text-sm flex items-center justify-center gap-2 transition-opacity active:opacity-80 disabled:opacity-30"
+      >
+        <Phone className="w-5 h-5" style={{ color: GOLD }} />
+        Continue with phone
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-[210] flex items-center justify-center px-6"
+          style={{ background: 'rgba(0,0,0,0.92)' }}
+        >
+          <div className="w-full max-w-xs">
+            <div className="flex items-center justify-between mb-6">
+              <h3 className="text-white text-lg font-black uppercase tracking-tight">
+                {step === 'phone' ? 'Your phone' : 'Enter the code'}
+              </h3>
+              <button
+                onClick={reset}
+                className="p-2 bg-white/5 rounded-full text-white/40"
+                aria-label="Close phone sign-in"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+
+            {step === 'phone' && (
+              <form onSubmit={sendCode} className="flex flex-col gap-4">
+                <p className="text-white/40 text-xs leading-relaxed">
+                  We'll text you a 6-digit code. Standard SMS rates apply.
+                </p>
+                <input
+                  type="tel"
+                  value={phone}
+                  onChange={(e) => setPhone(e.target.value.replace(/[^+\d]/g, ''))}
+                  placeholder="+447700900123"
+                  className="w-full bg-transparent text-white py-3 border-b focus:outline-none text-lg font-mono placeholder:text-white/25"
+                  style={{ borderBottomColor: phone ? GOLD : '#333' }}
+                  autoFocus
+                  inputMode="tel"
+                  autoComplete="tel"
+                />
+                <button
+                  type="submit"
+                  disabled={loading || !E164_RE.test(phone)}
+                  className="w-full py-4 rounded-xl text-black font-bold text-base tracking-wide flex items-center justify-center gap-2 transition-opacity"
+                  style={{
+                    backgroundColor: GOLD,
+                    opacity: loading || !E164_RE.test(phone) ? 0.3 : 1,
+                  }}
+                >
+                  {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : 'Send code'}
+                </button>
+              </form>
+            )}
+
+            {step === 'code' && (
+              <form onSubmit={verifyCode} className="flex flex-col gap-4">
+                <p className="text-white/40 text-xs leading-relaxed">
+                  Code sent to <span className="text-white/80 font-semibold">{phone}</span>
+                </p>
+                <input
+                  type="text"
+                  value={code}
+                  onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 8))}
+                  placeholder="123456"
+                  className="w-full bg-transparent text-white py-3 border-b focus:outline-none text-2xl font-mono tracking-[0.4em] text-center placeholder:text-white/15"
+                  style={{ borderBottomColor: code ? GOLD : '#333' }}
+                  autoFocus
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                  maxLength={8}
+                />
+                <button
+                  type="submit"
+                  disabled={loading || code.length < 4}
+                  className="w-full py-4 rounded-xl text-black font-bold text-base tracking-wide flex items-center justify-center gap-2 transition-opacity"
+                  style={{
+                    backgroundColor: GOLD,
+                    opacity: loading || code.length < 4 ? 0.3 : 1,
+                  }}
+                >
+                  {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : 'Verify'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setStep('phone'); setCode(''); setError(''); }}
+                  className="text-white/40 text-xs"
+                >
+                  Wrong number? Start over
+                </button>
+              </form>
+            )}
+
+            {error && (
+              <p className="text-red-400 text-xs mt-4 text-center">{error}</p>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/onboarding/screens/SignUpScreen.jsx
+++ b/src/components/onboarding/screens/SignUpScreen.jsx
@@ -24,6 +24,7 @@ import { Loader2, ChevronDown, ChevronUp } from 'lucide-react';
 import { ProgressDots } from './AgeGateScreen';
 import { track } from '@/lib/analytics';
 import TelegramLoginButton from '../TelegramLoginButton';
+import PhoneOtpButton from '../PhoneOtpButton';
 
 const GOLD = '#C8962C';
 
@@ -154,6 +155,7 @@ export default function SignUpScreen({ isSignIn = false }) {
             </p>
           )}
 
+          <PhoneOtpButton disabled={loading} />
           <TelegramLoginButton disabled={loading} />
         </div>
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -864,6 +864,26 @@ function localApiRoutes() {
             });
         }
 
+        if (path === '/api/auth/phone-otp-send' && method === 'POST') {
+          return importFresh('./api/auth/phone-otp-send.js')
+            .then((mod) => (mod.default || mod)(req, res))
+            .catch((error) => {
+              res.statusCode = 500;
+              res.setHeader('Content-Type', 'application/json');
+              res.end(JSON.stringify({ error: error?.message || 'phone-otp-send handler error' }));
+            });
+        }
+
+        if (path === '/api/auth/phone-otp-verify' && method === 'POST') {
+          return importFresh('./api/auth/phone-otp-verify.js')
+            .then((mod) => (mod.default || mod)(req, res))
+            .catch((error) => {
+              res.statusCode = 500;
+              res.setHeader('Content-Type', 'application/json');
+              res.end(JSON.stringify({ error: error?.message || 'phone-otp-verify handler error' }));
+            });
+        }
+
         // ── Daily check-in ──────────────────────────────────────────────────
         if (path === '/api/daily-checkin' && (method === 'GET' || method === 'POST')) {
           return importFresh('./api/daily-checkin.js')


### PR DESCRIPTION
## Summary
Adds **Continue with phone** to \`SignUpScreen\` as a 1-tap entry. Wires Twilio Verify for the SMS OTP send/check, then bridges the verified phone into a Supabase session via \`admin.generateLink('magiclink')\`.

## Frontend
- \`src/components/onboarding/PhoneOtpButton.jsx\` — drop-in button + inline 2-step flow (E.164 phone → 6-digit code → action_link redeem). Inline regex E.164 validation; switching to \`react-phone-number-input\` is a follow-up PR (kept dep-free for now).
- \`src/components/onboarding/screens/SignUpScreen.jsx\` — mounts the button inside the OAuth column, between Google and "More options".
- \`vite.config.js\` — registers \`/api/auth/phone-otp-{send,verify}\` for local dev.

## Backend
- \`api/auth/phone-otp-send.js\` — POSTs to Twilio Verify \`/Verifications\` with the supplied E.164 phone, channel=sms.
- \`api/auth/phone-otp-verify.js\` — POSTs to \`/VerificationCheck\`. On \`approved\` status, upserts a Supabase user keyed by phone (synthetic \`{digits}@hotmess.phone\` email so \`admin.generateLink('magiclink')\` works), then returns an \`action_link\` the client redirects to. The action_link lands on \`/auth/callback\` with a fresh session.

## Required env (Phil to provision)
\`\`\`
TWILIO_ACCOUNT_SID
TWILIO_AUTH_TOKEN
TWILIO_VERIFY_SERVICE_SID
\`\`\`

Provisioning steps:
1. Twilio Console → Verify → create a Verify Service → copy Service SID
2. Twilio Console → API Keys & Tokens → copy Account SID + Auth Token
3. Vercel → Project Settings → Env Vars → add all three

Until those are set the endpoints return clean 500s with \`MISSING_TWILIO_VERIFY_SID\` and the UI surfaces:
> Phone sign-in isn't set up yet. Try Apple, Google, or email.

No silent failures.

## Why \`admin.generateLink\` instead of minting a JWT
Custom JWT minting needs \`SUPABASE_JWT_SECRET\` + manual HS256 signing + matching aud/role/sub claims to Supabase's expectations. \`generateLink('magiclink')\` is server-side-only too but uses Supabase's own minting machinery, already supported in \`@supabase/supabase-js\` admin client, and is essentially the documented pattern for "I verified this user out of band, give me a session".

## Test plan
- [ ] Without env vars: tap "Continue with phone" → enter +447700900123 → submit → see "Phone sign-in isn't set up yet"
- [ ] With env vars: enter phone → receive SMS → enter code → land on /pulse with session
- [ ] Invalid phone (no \`+\`, too short, etc.): submit blocked client-side
- [ ] Wrong code: see "That code didn't match"
- [ ] Network down: see network error message

## Wave Auth · 2 of 3 auth PRs
- A1 #257 remove magic link, expose email+password under More options
- **A2 (this)**: phone OTP via Twilio Verify
- A3: Telegram Login Widget