### PR TITLE
fix(maps): move reverse geocode to server-side proxy

### DIFF
--- a/api/geocode/reverse.js
+++ b/api/geocode/reverse.js
@@ -1,0 +1,107 @@
+/**
+ * POST /api/geocode/reverse
+ *
+ * Server-side proxy for Google Maps Geocoding (reverse direction).
+ * Body: { lat: number, lng: number }
+ *
+ * Why this exists:
+ *   The frontend used to call maps.googleapis.com directly. After CSP #260
+ *   unblocked the request, Google rejected it with "API keys with referer
+ *   restrictions cannot be used with this API" — the Geocoding REST API
+ *   doesn't accept referer-restricted keys from browser-context calls.
+ *   So we move the call server-side, where the key is never exposed and
+ *   no Referer is required.
+ *
+ * Env required:
+ *   GOOGLE_MAPS_API_KEY        (server-side key — preferred; no referer
+ *                               restriction, or IP-restricted to Vercel
+ *                               egress IPs)
+ *   VITE_GOOGLE_MAPS_API_KEY   (legacy fallback; will work as long as the
+ *                               key isn't referer-restricted)
+ *
+ * Returns:
+ *   200 { city, neighborhood, full_address, area }
+ *   400 { error: 'invalid_coordinates' }
+ *   503 { error: 'GOOGLE_MAPS_API_KEY not configured' }
+ *   502 { error: 'google_unreachable' | 'google_rejected' }
+ */
+
+function pickComponent(addressComponents, types) {
+  for (const t of types) {
+    const match = addressComponents.find((c) => c.types.includes(t));
+    if (match) return match.long_name;
+  }
+  return null;
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const apiKey = process.env.GOOGLE_MAPS_API_KEY || process.env.VITE_GOOGLE_MAPS_API_KEY;
+  if (!apiKey || apiKey === 'your_google_maps_key') {
+    return res.status(503).json({ error: 'GOOGLE_MAPS_API_KEY not configured' });
+  }
+
+  const lat = Number(req.body?.lat);
+  const lng = Number(req.body?.lng);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng) || Math.abs(lat) > 90 || Math.abs(lng) > 180) {
+    return res.status(400).json({ error: 'invalid_coordinates' });
+  }
+
+  // result_type filter narrows the response and reduces quota burn.
+  // Same set of types the original useGPS.ts call used.
+  const url =
+    `https://maps.googleapis.com/maps/api/geocode/json` +
+    `?latlng=${lat},${lng}` +
+    `&result_type=neighborhood|sublocality|locality` +
+    `&key=${encodeURIComponent(apiKey)}`;
+
+  let data;
+  try {
+    const r = await fetch(url);
+    data = await r.json().catch(() => ({}));
+    if (!r.ok) {
+      return res.status(502).json({
+        error: 'google_unreachable',
+        status: r.status,
+        google_status: data?.status,
+      });
+    }
+  } catch (e) {
+    return res.status(502).json({ error: 'google_unreachable', detail: e.message });
+  }
+
+  if (data?.status !== 'OK' || !Array.isArray(data.results) || data.results.length === 0) {
+    return res.status(200).json({
+      city: null,
+      neighborhood: null,
+      full_address: null,
+      area: null,
+      google_status: data?.status,
+    });
+  }
+
+  // Pick the most descriptive result for "area"
+  const result =
+    data.results.find((r) => r.types.includes('neighborhood')) ||
+    data.results.find((r) => r.types.includes('sublocality')) ||
+    data.results.find((r) => r.types.includes('locality')) ||
+    data.results[0];
+
+  const components = result.address_components || [];
+  const neighborhood = pickComponent(components, ['neighborhood', 'sublocality_level_1', 'sublocality']);
+  const city = pickComponent(components, ['locality', 'postal_town', 'administrative_area_level_2']);
+  const area =
+    neighborhood ||
+    city ||
+    (result.formatted_address ? result.formatted_address.split(',')[0] : null);
+
+  return res.status(200).json({
+    city,
+    neighborhood,
+    full_address: result.formatted_address || null,
+    area,
+  });
+}

--- a/src/hooks/useGPS.ts
+++ b/src/hooks/useGPS.ts
@@ -101,28 +101,25 @@ export function useGPS(autoUpdate = true): UseGPSResult {
       }
 
       // ── Reverse Geocode for Area Name ──────────────────────────────────────
-      let locationArea = null;
-      const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
-      if (!apiKey) {
-        console.warn('[useGPS] VITE_GOOGLE_MAPS_API_KEY not set, skipping reverse geocode');
-      } else {
-        try {
-          const response = await fetch(
-            `https://maps.googleapis.com/maps/api/geocode/json?latlng=${newPosition.lat},${newPosition.lng}&key=${apiKey}&result_type=neighborhood|sublocality|locality`
-          );
-          const geoData = await response.json();
-          if (geoData.status === 'OK' && geoData.results?.length > 0) {
-            // Find the most descriptive "neighborhood" or "sublocality"
-            const bestMatch = geoData.results.find(r => r.types.includes('neighborhood'))
-                          || geoData.results.find(r => r.types.includes('sublocality'))
-                          || geoData.results[0];
-
-            locationArea = bestMatch.address_components[0].long_name;
-            console.log('[useGPS] 📍 Reverse geocoded area:', locationArea);
-          }
-        } catch (err) {
-          console.warn('[useGPS] Reverse geocoding failed:', err);
+      // 2026-05-09: moved to /api/geocode/reverse server proxy. Google's
+      // Geocoding REST API rejects referer-restricted keys called from
+      // browser context, so the request goes server-side now.
+      let locationArea: string | null = null;
+      try {
+        const response = await fetch('/api/geocode/reverse', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ lat: newPosition.lat, lng: newPosition.lng }),
+        });
+        const data = await response.json().catch(() => ({}));
+        if (response.ok && data?.area) {
+          locationArea = data.area;
+          console.log('[useGPS] 📍 Reverse geocoded area:', locationArea);
+        } else if (!response.ok) {
+          console.warn('[useGPS] Reverse geocode proxy error:', data?.error || response.status);
         }
+      } catch (err) {
+        console.warn('[useGPS] Reverse geocoding failed:', err);
       }
 
       const locUpdate: Record<string, any> = {

--- a/src/utils/locationService.js
+++ b/src/utils/locationService.js
@@ -1,43 +1,40 @@
 import { supabase } from '@/components/utils/supabaseClient';
 import { safeGetViewerLatLng } from './geolocation';
 
-const GOOGLE_MAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY || import.meta.env.GOOGLE_MAPS_API_KEY;
-
 /**
- * Reverse geocode coordinates to get a neighbourhood/area name using Google Maps API.
+ * Reverse geocode coordinates to get a neighbourhood / area name.
+ *
+ * 2026-05-09: moved from a direct browser fetch to maps.googleapis.com
+ * over to the /api/geocode/reverse server-side proxy. Google rejects
+ * referer-restricted keys on the Geocoding REST API when called from
+ * the browser; the proxy uses GOOGLE_MAPS_API_KEY (server-side env) so
+ * the key is never exposed and no Referer header is required.
  */
 export async function reverseGeocode(lat, lng) {
-  if (!GOOGLE_MAPS_API_KEY || GOOGLE_MAPS_API_KEY === 'your_google_maps_key') {
-    console.warn('[LocationService] Google Maps API key not configured.');
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
     return null;
   }
 
   try {
-    const url = `https://maps.googleapis.com/maps/api/geocode/json?latlng=${lat},${lng}&key=${GOOGLE_MAPS_API_KEY}`;
-    const response = await fetch(url);
-    const data = await response.json();
-
-    if (data.status === 'OK' && data.results.length > 0) {
-      // Look for neighborhood, sublocality, or locality
-      const result = data.results.find(r => 
-        r.types.includes('neighborhood') || 
-        r.types.includes('sublocality') || 
-        r.types.includes('locality')
-      ) || data.results[0];
-
-      // Extract the short name of the specific area
-      const areaComponent = result.address_components.find(c => 
-        c.types.includes('neighborhood') || 
-        c.types.includes('sublocality_level_1') || 
-        c.types.includes('locality')
-      );
-
-      return areaComponent ? areaComponent.long_name : result.formatted_address.split(',')[0];
+    const r = await fetch('/api/geocode/reverse', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ lat, lng }),
+    });
+    const data = await r.json().catch(() => ({}));
+    if (!r.ok) {
+      if (data?.error === 'GOOGLE_MAPS_API_KEY not configured') {
+        console.warn('[LocationService] Google Maps server-side key not set; skipping reverse geocode.');
+      } else {
+        console.warn('[LocationService] Reverse geocode proxy error:', data?.error || r.status);
+      }
+      return null;
     }
+    return data?.area || null;
   } catch (err) {
-    console.error('[LocationService] Reverse geocode failed:', err);
+    console.warn('[LocationService] Reverse geocode failed:', err?.message || err);
+    return null;
   }
-  return null;
 }
 
 /**

--- a/vite.config.js
+++ b/vite.config.js
@@ -854,6 +854,16 @@ function localApiRoutes() {
             });
         }
 
+        if (path === '/api/geocode/reverse' && method === 'POST') {
+          return importFresh('./api/geocode/reverse.js')
+            .then((mod) => (mod.default || mod)(req, res))
+            .catch((error) => {
+              res.statusCode = 500;
+              res.setHeader('Content-Type', 'application/json');
+              res.end(JSON.stringify({ error: error?.message || 'geocode/reverse handler error' }));
+            });
+        }
+
         if (path === '/api/auth/magic-link' && method === 'POST') {
           return importFresh('./api/auth/magic-link.js')
             .then((mod) => (mod.default || mod)(req, res))


### PR DESCRIPTION
## Summary
After CSP fix #260 unblocked the request to \`maps.googleapis.com\`, Google now responds with HTTP 200 — but rejects the call with:

> "API keys with referer restrictions cannot be used with this API"

The Geocoding REST API doesn't accept referer-restricted keys from browser-context calls (Cowork verified via direct \`fetch\` vs \`curl\` comparison this morning).

**Fix**: move the reverse-geocode call server-side. Browser hits the proxy, proxy hits Google with a non-referer-restricted server key, returns the area name. Key never touches the client bundle and no \`Referer\` header is sent.

## Prerequisites
- **#260** (CSP allow maps.googleapis.com) — required to even reach Google. ✅ merged.

## New endpoint
\`\`\`
POST /api/geocode/reverse
Body:    { lat: number, lng: number }
Returns: { city, neighborhood, full_address, area }
503:     GOOGLE_MAPS_API_KEY not configured
400:     invalid_coordinates
502:     google_unreachable
\`\`\`

## Frontend changes
- \`src/utils/locationService.js\` — drop direct Google fetch, call \`/api/geocode/reverse\`. Same callsite shape (returns area string).
- \`src/hooks/useGPS.ts\` — same migration.
- \`vite.config.js\` — register \`/api/geocode/reverse\` for local dev.

## Required env (Phil to provision)
\`\`\`
GOOGLE_MAPS_API_KEY  (server-side; no referer restriction —
                      ideally IP-restricted to Vercel egress IPs)
\`\`\`

The legacy \`VITE_GOOGLE_MAPS_API_KEY\` is honoured as a fallback if it's not referer-restricted. Until either is set, the proxy returns 503 with \`GOOGLE_MAPS_API_KEY not configured\` and the UI gracefully skips the area name (rest of location sync still happens — just no human-readable area).

## Verify after merge + redeploy
1. Wait ~90s for Vercel auto-deploy
2. Hard reload \`https://hotmessldn.com/pulse\` (or open in incognito)
3. Console should NOT log \`[LocationService] Reverse geocode failed\`
4. Globe should auto-zoom to user location within 3 seconds
5. \`profiles.location_area\` should populate on next sync (~30s)